### PR TITLE
Jwt auth

### DIFF
--- a/openIMIS/openIMIS/oijwt.py
+++ b/openIMIS/openIMIS/oijwt.py
@@ -10,8 +10,6 @@ logger = logging.getLogger(__file__)
 
 
 def jwt_encode_user_key(payload, context=None):
-    logger.info("foo")
-    user_private_key = extract_private_key_from_context(context)
     token = jwt.encode(
         payload,
         get_jwt_key(encode=True, context=context),

--- a/openIMIS/openIMIS/oijwt.py
+++ b/openIMIS/openIMIS/oijwt.py
@@ -1,0 +1,85 @@
+# from graphql_auth.backends import GraphQLAuthBackend
+# from django.utils.deprecation import MiddlewareMixin
+import jwt
+from graphql_jwt.settings import jwt_settings
+from django.apps import apps
+
+import logging
+
+logger = logging.getLogger(__file__)
+
+
+def jwt_encode_user_key(payload, context=None):
+    logger.info("foo")
+    user_private_key = extract_private_key_from_context(context)
+    token = jwt.encode(
+        payload,
+        get_jwt_key(encode=True, context=context),
+        jwt_settings.JWT_ALGORITHM,
+    )
+    # JWT module after 1.7 does the encoding, introducing some conflicts in graphql-jwt, let's support both
+    if isinstance(token, bytes):
+        token = token.decode("utf-8")
+    return token
+
+
+def jwt_decode_user_key(token, context=None):
+    # First decode the token without validating it, so we can extract the username
+    not_validated = jwt.decode(
+        token,
+        get_jwt_key(encode=False, context=context),
+        options={
+            'verify_exp': jwt_settings.JWT_VERIFY_EXPIRATION,
+            'verify_aud': jwt_settings.JWT_AUDIENCE is not None,
+            'verify_signature': False,
+        },
+        leeway=jwt_settings.JWT_LEEWAY,
+        audience=jwt_settings.JWT_AUDIENCE,
+        issuer=jwt_settings.JWT_ISSUER,
+        algorithms=[jwt_settings.JWT_ALGORITHM],
+    )
+    if not_validated and not_validated.get("username"):
+        user_class = apps.get_model("core", "User")
+        db_user = user_class.objects\
+            .filter(username=not_validated.get("username"))\
+            .only("i_user__private_key")\
+            .first()
+        if db_user and db_user.private_key:
+            key = db_user.private_key
+        else:
+            key = get_jwt_key(encode=False)
+    else:
+        key = get_jwt_key(encode=False)
+    return jwt.decode(
+        token,
+        key,
+        options={
+            'verify_exp': jwt_settings.JWT_VERIFY_EXPIRATION,
+            'verify_aud': jwt_settings.JWT_AUDIENCE is not None,
+            'verify_signature': jwt_settings.JWT_VERIFY,
+        },
+        leeway=jwt_settings.JWT_LEEWAY,
+        audience=jwt_settings.JWT_AUDIENCE,
+        issuer=jwt_settings.JWT_ISSUER,
+        algorithms=[jwt_settings.JWT_ALGORITHM],
+    )
+
+
+def get_jwt_key(encode=True, context=None):
+    user_key = extract_private_key_from_context(context)
+    if user_key:
+        return user_key
+    if encode:
+        if hasattr(jwt_settings, "JWT_PRIVATE_KEY"):
+            return jwt_settings.JWT_PRIVATE_KEY
+    else:
+        if hasattr(jwt_settings, "JWT_PUBLIC_KEY"):
+            return jwt_settings.JWT_PUBLIC_KEY
+    return jwt_settings.JWT_SECRET_KEY
+
+
+def extract_private_key_from_context(context):
+    if context and context.user and hasattr(context.user, "private_key"):
+        return context.user.private_key
+    return None
+

--- a/openIMIS/openIMIS/schema.py
+++ b/openIMIS/openIMIS/schema.py
@@ -1,4 +1,6 @@
 import graphene
+import graphql_jwt
+
 from core.models import Language
 from django.utils import translation
 
@@ -60,7 +62,10 @@ class Query(*queries, graphene.ObjectType):
 
 
 class Mutation(*mutations, graphene.ObjectType):
-    pass
+    token_auth = graphql_jwt.mutations.ObtainJSONWebToken.Field()
+    verify_token = graphql_jwt.mutations.Verify.Field()
+    refresh_token = graphql_jwt.mutations.Refresh.Field()
+    revoke_token = graphql_jwt.mutations.Revoke.Field()
 
 
 class GQLUserLanguageMiddleware:

--- a/openIMIS/openIMIS/settings.py
+++ b/openIMIS/openIMIS/settings.py
@@ -133,6 +133,7 @@ INSTALLED_APPS = [
     'django.contrib.messages',
     'django.contrib.staticfiles',
     'graphene_django',
+    'graphql_jwt.refresh_token.apps.RefreshTokenConfig',
     'test_without_migrations',
     'rest_framework',
     'rules',
@@ -152,6 +153,7 @@ if bool(os.environ.get("REMOTE_USER_AUTHENTICATION", False)):
 
 AUTHENTICATION_BACKENDS += [
     'rules.permissions.ObjectPermissionBackend',
+    'graphql_jwt.backends.JSONWebTokenBackend',
     'django.contrib.auth.backends.ModelBackend',
 ]
 
@@ -170,7 +172,9 @@ MIDDLEWARE = [
     'django.middleware.locale.LocaleMiddleware',
     'django.middleware.common.CommonMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',
-    'django.contrib.auth.middleware.AuthenticationMiddleware'
+    'django.contrib.auth.middleware.AuthenticationMiddleware',
+    #'openIMIS.oijwt.OIGraphQLAuthBackend'
+    #'graphql_jwt.middleware.JSONWebTokenMiddleware',
 ]
 
 
@@ -209,6 +213,22 @@ GRAPHENE = {
     'MIDDLEWARE': [
         'openIMIS.schema.GQLUserLanguageMiddleware',
         #'graphene_django.debug.DjangoDebugMiddleware',  # adds a _debug query to graphQL with sql debug info
+        'graphql_jwt.middleware.JSONWebTokenMiddleware',
+        #'graphql_auth.backends.GraphQLAuthBackend',
+    ]
+}
+
+GRAPHQL_JWT = {
+    "JWT_VERIFY_EXPIRATION": True,
+    "JWT_LONG_RUNNING_REFRESH_TOKEN": True,
+    "JWT_ENCODE_HANDLER": "openIMIS.oijwt.jwt_encode_user_key",
+    "JWT_DECODE_HANDLER": "openIMIS.oijwt.jwt_decode_user_key",
+    # This can be used to expose some resources without authentication
+    "JWT_ALLOW_ANY_CLASSES": [
+        "graphql_jwt.mutations.ObtainJSONWebToken",
+        "graphql_jwt.mutations.Verify",
+        "graphql_jwt.mutations.Refresh",
+        "graphql_jwt.mutations.Revoke",
     ]
 }
 

--- a/openIMIS/openIMIS/urls.py
+++ b/openIMIS/openIMIS/urls.py
@@ -18,12 +18,13 @@ from django.contrib import admin
 from django.urls import path
 from django.views.decorators.csrf import csrf_exempt
 from graphene_django.views import GraphQLView
+from graphql_jwt.decorators import jwt_cookie
 
 from .openimisurls import openimis_urls
 from .settings import SITE_ROOT
 
 urlpatterns = [
     path("%sadmin/" % SITE_ROOT(), admin.site.urls),
-    path("%sgraphql" % SITE_ROOT(), csrf_exempt(GraphQLView.as_view(graphiql=True))),
+    path("%sgraphql" % SITE_ROOT(), jwt_cookie(csrf_exempt(GraphQLView.as_view(graphiql=True)))),
     url(r'^ht/', include('health_check.urls')),
 ] + openimis_urls()

--- a/openimis.json
+++ b/openimis.json
@@ -59,6 +59,10 @@
     {
       "name": "dhis2_etl",
       "pip": "-e git+https://github.com/openimis/openimis-be-dhis2_etl_py.git@develop#egg=openimis-be-dhis2_etl"
+    },
+    {
+      "name": "api_fhir_r4",
+      "pip": "-e git+https://github.com/openimis/openimis-be-api_fhir_r4_py.git@develop#egg=openimis-be-api_fhir_r4"
     }
   ]
 }

--- a/openimis.json
+++ b/openimis.json
@@ -55,6 +55,10 @@
     {
       "name": "api_fhir",
       "pip": "openimis-be-api_fhir==1.2.0rc1"
+    },
+    {
+      "name": "dhis2_etl",
+      "pip": "-e git+https://github.com/openimis/openimis-be-dhis2_etl_py.git@develop"
     }
   ]
 }

--- a/openimis.json
+++ b/openimis.json
@@ -58,7 +58,7 @@
     },
     {
       "name": "dhis2_etl",
-      "pip": "-e git+https://github.com/openimis/openimis-be-dhis2_etl_py.git@develop"
+      "pip": "-e git+https://github.com/openimis/openimis-be-dhis2_etl_py.git@develop#egg=openimis-be-dhis2_etl"
     }
   ]
 }

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,6 +14,8 @@ django-rest-framework-rules
 django-test-without-migrations
 graphene-django==2.8.2
 graphene-django-optimizer
+PyJWT==1.7.0
+django-graphql-jwt==0.3.1
 markdown
 nepalicalendar
 numpy


### PR DESCRIPTION
Add JWT Authentication to the backend.
PyJWT and django-graphql-jwt are pulled back because the latest version are not compatible with the stable release of Graphene.
The scheme can be run in parallel to the existing model.