### PR TITLE
Allow Basic and SessionAuthentication on REST

### DIFF
--- a/openIMIS/openIMIS/settings.py
+++ b/openIMIS/openIMIS/settings.py
@@ -162,6 +162,8 @@ ANONYMOUS_USER_NAME = None
 REST_FRAMEWORK = {
     'DEFAULT_AUTHENTICATION_CLASSES': (
         'core.jwt_authentication.JWTAuthentication',
+        'rest_framework.authentication.BasicAuthentication',
+        'rest_framework.authentication.SessionAuthentication',
     ),
     'DEFAULT_PERMISSION_CLASSES': [
         'core.security.ObjectPermissions'


### PR DESCRIPTION
This is temporarily necessary for the frontend to call the currentuser endpoint without JWT.
We will soon replace this frontend login with the JWT token as well.