### PR TITLE
define-site-url

### DIFF
--- a/openIMIS/openIMIS/settings.py
+++ b/openIMIS/openIMIS/settings.py
@@ -105,6 +105,14 @@ def SITE_ROOT():
     else:
         return "%s/" % root
 
+def SITE_URL():
+    url = os.environ.get("SITE_URL", '')
+    if (url == ''):
+        return url
+    elif (url.endswith('/')):
+        return url[:-1]
+    else:
+        return url
 
 # Quick-start development settings - unsuitable for production
 # See https://docs.djangoproject.com/en/2.1/howto/deployment/checklist/


### PR DESCRIPTION
to be added on the compse or as ENV varriables
      - SITE_URL=${NEW_OPENIMIS_HOST}
to be used in FHIR API to create "correct" URL reference /code systems