### PR TITLE
OPL-13: Include service signal decorator logic in main backend

### DIFF
--- a/openIMIS/openIMIS/settings.py
+++ b/openIMIS/openIMIS/settings.py
@@ -158,6 +158,7 @@ INSTALLED_APPS = [
     'channels'                                  # Websocket support
 ]
 INSTALLED_APPS += openimis_apps()
+INSTALLED_APPS += ['signal_binding']            # Signal binding should be last installed module
 
 AUTHENTICATION_BACKENDS = []
 if bool(os.environ.get("REMOTE_USER_AUTHENTICATION", False)):

--- a/openIMIS/openIMIS/settings.py
+++ b/openIMIS/openIMIS/settings.py
@@ -17,6 +17,9 @@ from .openimisapps import openimis_apps, get_locale_folders
 
 load_dotenv()
 
+# Makes openimis_apps available to other modules
+OPENIMIS_APPS = openimis_apps()
+
 # Build paths inside the project like this: os.path.join(BASE_DIR, ...)
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 
@@ -157,7 +160,7 @@ INSTALLED_APPS = [
     'django_apscheduler',
     'channels'                                  # Websocket support
 ]
-INSTALLED_APPS += openimis_apps()
+INSTALLED_APPS += OPENIMIS_APPS
 INSTALLED_APPS += ['signal_binding']            # Signal binding should be last installed module
 
 AUTHENTICATION_BACKENDS = []

--- a/openIMIS/signal_binding/__init__.py
+++ b/openIMIS/signal_binding/__init__.py
@@ -1,0 +1,1 @@
+default_app_config = 'signal_binding.apps.SignalBindingConfig'

--- a/openIMIS/signal_binding/apps.py
+++ b/openIMIS/signal_binding/apps.py
@@ -1,0 +1,51 @@
+import io
+import json
+import os
+
+from django.apps import AppConfig
+import logging
+from django.apps import AppConfig
+
+
+logger = logging.getLogger(__name__)
+
+
+class SignalBindingConfig(AppConfig):
+    name = 'signal_binding'
+
+    def ready(self):
+        self.bind_service_signals()
+
+    def bind_service_signals(self):
+        def extract_app(module):
+            return "%s" % (module["name"])
+
+        def openimis_apps():
+            OPENIMIS_CONF = load_openimis_conf()
+            return [*map(extract_app, OPENIMIS_CONF["modules"])]
+
+        def load_openimis_conf(conf_file_param='../openimis.json'):
+            conf_json_env = os.environ.get("OPENIMIS_CONF_JSON", "")
+            conf_file_path = os.environ.get("OPENIMIS_CONF", conf_file_param)
+            if not conf_json_env:
+                with open(conf_file_path) as conf_file:
+                    return json.load(conf_file)
+            else:
+                conf_json_env = io.StringIO(conf_json_env)
+                return json.load(conf_json_env)
+
+        for app in openimis_apps():
+            self._bind_app_signals(app)
+
+    def _bind_app_signals(self, app_):
+        try:
+            signals_module = __import__(f"{app_}.signals")
+            if hasattr(signals_module.signals, "bind_service_signals"):
+                signals_module.signals.bind_service_signals()
+                logger.debug(f"{app_} service signals connected")
+            else:
+                logger.debug(f"{app_} has a signals module but no bind_service_signals function")
+        except ModuleNotFoundError as exc:
+            logger.debug(f"{app_} has no signals module, skipping")
+        except Exception as exc:
+            logger.debug(f"{app_}: unknown exception occurred during bind_service_signals: {exc}")

--- a/openIMIS/signal_binding/apps.py
+++ b/openIMIS/signal_binding/apps.py
@@ -1,11 +1,6 @@
-import io
-import json
-import os
-
-from django.apps import AppConfig
 import logging
 from django.apps import AppConfig
-
+from django.conf import settings
 
 logger = logging.getLogger(__name__)
 
@@ -17,24 +12,7 @@ class SignalBindingConfig(AppConfig):
         self.bind_service_signals()
 
     def bind_service_signals(self):
-        def extract_app(module):
-            return "%s" % (module["name"])
-
-        def openimis_apps():
-            OPENIMIS_CONF = load_openimis_conf()
-            return [*map(extract_app, OPENIMIS_CONF["modules"])]
-
-        def load_openimis_conf(conf_file_param='../openimis.json'):
-            conf_json_env = os.environ.get("OPENIMIS_CONF_JSON", "")
-            conf_file_path = os.environ.get("OPENIMIS_CONF", conf_file_param)
-            if not conf_json_env:
-                with open(conf_file_path) as conf_file:
-                    return json.load(conf_file)
-            else:
-                conf_json_env = io.StringIO(conf_json_env)
-                return json.load(conf_json_env)
-
-        for app in openimis_apps():
+        for app in settings.OPENIMIS_APPS:
             self._bind_app_signals(app)
 
     def _bind_app_signals(self, app_):


### PR DESCRIPTION
Adds new app loaded to OpenIMIS through settings. During ready() call application is crawling modules for service signals receivers ([see PR](https://github.com/openimis/openimis-be-core_py/pull/77)) and connects them to signal. 
Developed as part of [OPL-13](https://openimis.atlassian.net/browse/OPL-13)