### PR TITLE
OPL-67: Add Swagger to FHIR Api

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -101,4 +101,4 @@ jobs:
           DB_PASSWORD: GitHub999
           #DEV_SERVER: true
           SITE_ROOT: api
-          REMOTE_USER_AUTHENTICATION: True
+          REMOTE_USER_AUTHENTICATION: False

--- a/openIMIS/openIMIS/settings.py
+++ b/openIMIS/openIMIS/settings.py
@@ -162,7 +162,8 @@ INSTALLED_APPS = [
     "health_check.storage",
     "django_apscheduler",
     "channels",  # Websocket support
-    "developer_tools"
+    "developer_tools",
+    "drf_spectacular"  # Swagger UI for FHIR API
 ]
 INSTALLED_APPS += OPENIMIS_APPS
 INSTALLED_APPS += ["signal_binding"]  # Signal binding should be last installed module
@@ -188,6 +189,17 @@ REST_FRAMEWORK = {
     ],
     "DEFAULT_PERMISSION_CLASSES": ["core.security.ObjectPermissions"],
     "EXCEPTION_HANDLER": "openIMIS.rest_exception_handler.fhir_rest_api_exception_handler",
+    'DEFAULT_SCHEMA_CLASS': 'drf_spectacular.openapi.AutoSchema',
+}
+
+SPECTACULAR_SETTINGS = {
+    'TITLE': 'FHIR R4',
+    'DESCRIPTION': 'openIMIS FHIR R4 API',
+    'VERSION': '1.0.0',
+    'AUTHENTICATION_WHITELIST': [
+        'core.jwt_authentication.JWTAuthentication',
+        'api_fhir_r4.views.CsrfExemptSessionAuthentication'
+    ],
 }
 
 if os.environ.get("REMOTE_USER_AUTHENTICATION", "false").lower() == "true":

--- a/requirements.txt
+++ b/requirements.txt
@@ -43,3 +43,4 @@ django-simple-history
 django-dirtyfields==1.4.1
 daphne==3.0.1
 GitPython==3.1.24
+drf-spectacular==0.21.2


### PR DESCRIPTION
[https://openimis.atlassian.net/browse/OPL-67](https://openimis.atlassian.net/browse/OPL-67)

Changes:
- Added drf-spectacular library, used to introspect django-rest-framework views to generate openapi 3 schema with `swagger` and `redoc` UI
- Added settings for drf-spectacular and rest fmatework 