### PR TITLE
OP-864 OP-864 CI error from api_fhir_r4 module

### DIFF
--- a/openIMIS/init_test_db.py
+++ b/openIMIS/init_test_db.py
@@ -13,7 +13,7 @@ test_databases, mirrored_aliases = get_unique_databases_and_mirrors()
 for db_host, db_port, db_engine, db_name in test_databases.keys():
     name, cfgs = test_databases[(db_host, db_port, db_engine, db_name)]
     for cfg in cfgs:
-        with connections[cfg]._nodb_connection.cursor() as c:
+        with connections[cfg].cursor() as c:
             c.execute("DROP DATABASE IF EXISTS %s" % db_name)
             c.execute("CREATE DATABASE %s" % db_name)
         if "postgres" in db_engine:


### PR DESCRIPTION
[https://openimis.atlassian.net/browse/OP-864](https://openimis.atlassian.net/browse/OP-864)

Changes:
- Fixed `init_test_db.py` (removed private property)