### PR TITLE
OTC-816: fix translation message variables

### DIFF
--- a/openIMIS/locale/en/LC_MESSAGES/django.po
+++ b/openIMIS/locale/en/LC_MESSAGES/django.po
@@ -63,7 +63,9 @@ msgid "claim.validation.product_family.waiting_period"
 msgstr "Item/service %s waiting period violation"
 
 msgid "claim.validation.product_family.max_nb_allowed"
-msgstr "Item/service %s, provided %s over maximum number allowed %s"
+msgstr ""
+"%(code)s: Item/service %(element)s, provided %(provided)s over maximum "
+"number allowed %(max)s"
 
 msgid "claim.validation.product_family.no_product_found"
 msgstr "No product item/service found for %s"

--- a/openIMIS/locale/fr/LC_MESSAGES/django.po
+++ b/openIMIS/locale/fr/LC_MESSAGES/django.po
@@ -60,7 +60,9 @@ msgid "claim.validation.product_family.waiting_period"
 msgstr "Violation du délai d'attente pour le soin  ou le produit médical %s"
 
 msgid "claim.validation.product_family.max_nb_allowed"
-msgstr "%s soins et %s produit médicaux est supérieur au nombre maximum de prestations et de produits de santé %s"
+msgstr ""
+"%(code): %(element) soins et %(provided) produit médicaux est supérieur au "
+"nombre maximum de prestations et de produits de santé %(max)"
 
 msgid "claim.validation.product_family.no_product_found"
 msgstr "Pas de produit/soin trouvé pour %s"


### PR DESCRIPTION
https://openimis.atlassian.net/browse/OTC-816

This PR updates translation message to match the number of arguments in formatted string. I also updated localise page with this key:
https://app.lokalise.com/project/539322845d9e1249837338.65707886/?view=single&reference_lang_id=640&single_lang_id=640&search=nb_allowed