### PR TITLE
OTC-908: add limit code/username variable

### DIFF
--- a/openIMIS/openIMIS/settings.py
+++ b/openIMIS/openIMIS/settings.py
@@ -463,6 +463,8 @@ DATA_UPLOAD_MAX_MEMORY_SIZE = int(os.environ.get('DATA_UPLOAD_MAX_MEMORY_SIZE', 
 INSUREE_NUMBER_LENGTH = os.environ.get("INSUREE_NUMBER_LENGTH", None)
 INSUREE_NUMBER_MODULE_ROOT = os.environ.get("INSUREE_NUMBER_MODULE_ROOT", None)
 
+USER_USERNAME_AND_CODE_LENGTH_LIMIT = os.environ.get("USER_USERNAME_LIMIT", 50)  # actual length is managed in CoreConfig
+
 # There used to be a default password for zip files but for security reasons, it was removed. Trying to export
 # without a password defined is going to fail
 MASTER_DATA_PASSWORD = os.environ.get("MASTER_DATA_PASSWORD", None)


### PR DESCRIPTION
https://openimis.atlassian.net/browse/OTC-908

I decided to put variable responsible for model charField limitation here so there would be only one variable responsible for managing all of the models.

It is also related to: 
https://github.com/openimis/openimis-be-core_py/pull/158
https://github.com/openimis/openimis-be-claim_py/pull/84
https://github.com/openimis/openimis-fe-admin_js/pull/59