### PR TITLE
OP-1394: DRF rules package removed.

### DIFF
--- a/openIMIS/openIMIS/settings.py
+++ b/openIMIS/openIMIS/settings.py
@@ -151,7 +151,6 @@ INSTALLED_APPS = [
     "test_without_migrations",
     "rest_framework",
     "rules",
-    "rest_framework_rules",
     "health_check",  # required
     "health_check.db",  # stock Django health checkers
     "health_check.cache",

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,6 @@ django-filter~=22.1
 # Since Q3 2021, Microsoft is providing an official driver mssql-django, the engine needs to become "mssql"
 #django-mssql-backend==2.8.1
 mssql-django==1.1.3
-django-rest-framework-rules
 django-test-without-migrations
 graphene-django<3
 graphene-django-optimizer==0.8.0


### PR DESCRIPTION
Ticket: https://openimis.atlassian.net/browse/OP-1394

Changes:
- Removed django-rest-framework-rules from installed_apps and requirements.

After merging, rerun tests and merge:
https://github.com/openimis/openimis-be-core_py/pull/165

