### PR TITLE
OP-1394: DRF rules package removed. (#133)

### DIFF
--- a/openIMIS/openIMIS/settings.py
+++ b/openIMIS/openIMIS/settings.py
@@ -151,7 +151,6 @@ INSTALLED_APPS = [
     "test_without_migrations",
     "rest_framework",
     "rules",
-    "rest_framework_rules",
     "health_check",  # required
     "health_check.db",  # stock Django health checkers
     "health_check.cache",

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,6 @@ django-filter~=22.1
 # Since Q3 2021, Microsoft is providing an official driver mssql-django, the engine needs to become "mssql"
 #django-mssql-backend==2.8.1
 mssql-django==1.1.3
-django-rest-framework-rules
 django-test-without-migrations
 graphene-django<3
 graphene-django-optimizer==0.8.0


### PR DESCRIPTION
The pull request https://github.com/openimis/openimis-be-core_py/pull/165 on core requires this change not to crash. However, while the core develop branch was merged into the release one, this repo didn't have the same merge.

The effect of this missing change is that the latest release version produces:
<img width="1350" alt="image" src="https://github.com/openimis/openimis-be_py/assets/328253/cc091d29-d67e-4cc6-bfa0-c91a4568e51e">
Because the rights retrieval lists the modules and has an exclusion for that module... in the previous version. The merged change in "core" removes the exclusion but the be_py is still installing it.
