### PR TITLE
OTC-1080: added missing fields that cause tests to fail

### DIFF
--- a/openIMIS/init_test_db_pg.sql
+++ b/openIMIS/init_test_db_pg.sql
@@ -3192,8 +3192,8 @@ CREATE TABLE "public"."tblIMISDefaults" (
     "AppVersionFeedbackRenewal" numeric(3,1),
     "AppVersionImis" numeric(3,1),
     "APIKey" character varying(100),
-    "ActivationOption" smallint NOT NULL,
-    "BypassReviewClaim" boolean NOT NULL
+    "ActivationOption" smallint DEFAULT 2 NOT NULL,
+    "BypassReviewClaim" boolean DEFAULT true NOT NULL
 );
 
 

--- a/openIMIS/init_test_db_pg.sql
+++ b/openIMIS/init_test_db_pg.sql
@@ -2808,7 +2808,9 @@ CREATE TABLE "public"."tblFamilies" (
     "FamilyType" character varying(2),
     "InsureeID" integer NOT NULL,
     "LocationId" integer,
-    "RowID" "text"
+    "RowID" "text",
+    "Source" VARCHAR(50) NULL,
+    "SourceVersion" VARCHAR(15) NULL
 );
 
 
@@ -2838,6 +2840,17 @@ ALTER TABLE "public"."tblFamilies_FamilyID_seq" OWNER TO "postgres";
 
 ALTER SEQUENCE "public"."tblFamilies_FamilyID_seq" OWNED BY "public"."tblFamilies"."FamilyID";
 
+CREATE TABLE "public"."tblFamilySMS" (
+    FamilyID INT NOT NULL,
+    ApprovalOfSMS BOOLEAN,
+    LanguageOfSMS VARCHAR(5),
+    ValidityFrom TIMESTAMPTZ NOT NULL,
+    ValidityTo TIMESTAMPTZ,
+    CONSTRAINT UC_FamilySMS UNIQUE (FamilyID, ValidityTo)
+);
+
+
+ALTER TABLE "public"."tblFamilySMS" OWNER TO "postgres";
 
 --
 -- TOC entry 262 (class 1259 OID 20726)
@@ -3178,7 +3191,9 @@ CREATE TABLE "public"."tblIMISDefaults" (
     "SMSType" integer,
     "AppVersionFeedbackRenewal" numeric(3,1),
     "AppVersionImis" numeric(3,1),
-    "APIKey" character varying(100)
+    "APIKey" character varying(100),
+    "ActivationOption" smallint NOT NULL,
+    "BypassReviewClaim" boolean NOT NULL
 );
 
 
@@ -3191,7 +3206,8 @@ ALTER TABLE "public"."tblIMISDefaults" OWNER TO "postgres";
 
 CREATE TABLE "public"."tblIMISDefaultsPhone" (
     "RuleName" character varying(100),
-    "RuleValue" boolean
+    "RuleValue" boolean,
+    "Usage" character varying(200) NULL
 );
 
 
@@ -3248,7 +3264,9 @@ CREATE TABLE "public"."tblInsuree" (
     "ValidityTo" timestamp with time zone,
     "Vulnerability" boolean,
     "isOffline" boolean,
-    "passport" character varying(25)
+    "passport" character varying(25),
+    "Source" character varying(50) NULL,
+    "SourceVersion" character varying(15) NULL
 );
 
 
@@ -3388,7 +3406,8 @@ ALTER SEQUENCE "public"."tblItems_ItemID_seq" OWNED BY "public"."tblItems"."Item
 CREATE TABLE "public"."tblLanguages" (
     "LanguageCode" character varying(5) NOT NULL,
     "LanguageName" character varying(50) NOT NULL,
-    "SortOrder" integer
+    "SortOrder" integer,
+    "CountryCode" character varying(10) NULL
 );
 
 
@@ -3557,7 +3576,8 @@ CREATE TABLE "public"."tblPLItems" (
     "ValidityTo" timestamp with time zone,
     "LegacyID" integer,
     "AuditUserID" integer NOT NULL,
-    "LocationId" integer
+    "LocationId" integer,
+    "RowID" timestamp NULL
 );
 
 
@@ -3818,7 +3838,11 @@ CREATE TABLE "public"."tblPayment" (
     "DateLastSMS" timestamp with time zone,
     "LanguageName" character varying(10),
     "TypeOfPayment" character varying(50),
-    "TransferFee" numeric(18,2)
+    "TransferFee" numeric(18,2),
+    "SpReconcReqId" character varying(30) NULL,
+    "ReconciliationDate" timestamp NULL,
+    "PayerPhoneNumber" character varying(50) NULL,
+    "SmsRequired" bit NULL
 );
 
 
@@ -3921,7 +3945,9 @@ CREATE TABLE "public"."tblPolicy" (
     "FamilyID" integer NOT NULL,
     "OfficerID" integer,
     "ProdID" integer NOT NULL,
-    "RowID" "bytea"
+    "RowID" "bytea",
+    "Source" character varying(50) NULL,
+    "SourceVersion" character varying(15) NULL
 );
 
 
@@ -4019,7 +4045,10 @@ CREATE TABLE "public"."tblPremium" (
     "AuditUserID" integer NOT NULL,
     "PayerID" integer,
     "PolicyID" integer NOT NULL,
-    "RowID" "text"
+    "RowID" "text",
+    "CreatedDate" "date" DEFAULT CURRENT_DATE NOT NULL,
+    "Source" character varying(50) NULL,
+    "SourceVersion" character varying(15) NULL
 );
 
 
@@ -4348,7 +4377,8 @@ CREATE TABLE "public"."tblRelDistr" (
     "ValidityTo" timestamp with time zone,
     "LegacyID" integer,
     "AuditUserID" integer NOT NULL,
-    "ProdID" integer NOT NULL
+    "ProdID" integer NOT NULL,
+    "RowID" timestamp NULL
 );
 
 
@@ -4459,8 +4489,9 @@ CREATE TABLE "public"."tblReporting" (
     "RecordFound" integer NOT NULL,
     "OfficerID" integer,
     "ReportType" integer,
-    "CammissionRate" numeric(18,2),
-    "CommissionRate" numeric(18,2)
+    "ReportMode" integer,
+    "CommissionRate" numeric(18,2),
+    "Scope" integer
 );
 
 
@@ -4636,7 +4667,8 @@ CREATE TABLE "public"."tblUserRole" (
     "UserRoleID" integer NOT NULL,
     "AudituserID" integer,
     "RoleID" integer NOT NULL,
-    "UserID" integer NOT NULL
+    "UserID" integer NOT NULL,
+    "Assign" integer NULL
 );
 
 


### PR DESCRIPTION
Ticket:
https://openimis.atlassian.net/browse/OTC-1080

Changes:
- added missing fields for test database and now it is possible to run tests

Notes:
- differences between mssql and pssql like capital letters for "RowId"/"RowID"/"LegacyId"/"LegacyID" were not matched because it still work like this and changes may lead to unnecessary problems 