### PR TITLE
Adjust test database init to work with postgres properly

### DIFF
--- a/openIMIS/init_test_db.py
+++ b/openIMIS/init_test_db.py
@@ -13,12 +13,15 @@ test_databases, mirrored_aliases = get_unique_databases_and_mirrors()
 for db_host, db_port, db_engine, db_name in test_databases.keys():
     name, cfgs = test_databases[(db_host, db_port, db_engine, db_name)]
     for cfg in cfgs:
-        with connections[cfg].cursor() as c:
-            c.execute("DROP DATABASE IF EXISTS %s" % db_name)
-            c.execute("CREATE DATABASE %s" % db_name)
         if "postgres" in db_engine:
+            with connections[cfg].cursor() as c:
+                c.execute('DROP DATABASE IF EXISTS "%s"' % db_name)
+                c.execute('CREATE DATABASE "%s"' % db_name)
             os.system("PGPASSWORD='%s' psql -h %s -p %s -U %s %s -f init_test_db_pg.sql" %
                       (settings.DATABASES[cfg]['PASSWORD'], db_host, db_port, settings.DATABASES[cfg]['USER'], db_name))
         else:
+            with connections[cfg].cursor() as c:
+                c.execute("DROP DATABASE IF EXISTS %s" % db_name)
+                c.execute("CREATE DATABASE %s" % db_name)
             os.system("sqlcmd -S %s,%s -U %s -P '%s' -d %s -i init_test_db.sql" %
                       (db_host, db_port, settings.DATABASES[cfg]['USER'], settings.DATABASES[cfg]['PASSWORD'], db_name))


### PR DESCRIPTION
This PR will create case sensitive creation option for postgres. It also prevents from creating two test databases on postgres.