### PR TITLE
hotfix: remove social protection from openimis.json

### DIFF
--- a/openimis.json
+++ b/openimis.json
@@ -129,10 +129,6 @@
 			"pip":"git+https://github.com/openimis/openimis-be-dhis2_etl_py.git@develop#egg=openimis-be-dhis2_etl"
 		},
 		{
-			"name": "social_protection",
-			"pip": "git+https://github.com/openimis/openimis-be-social_protection_py.git@develop#egg=openimis-be-social_protection"
-		},
-		{
 			"name": "opensearch_reports",
 			"pip": "git+https://github.com/openimis/openimis-be-opensearch_reports_py.git@develop#egg=openimis-be-opensearch_reports"
 		},


### PR DESCRIPTION
Social protection module should not be a part of openIMIS. It is also dependent on individual module that is not in the openimis.json file. 