### PR TITLE
Migration error proof of concept

### DIFF
--- a/openimis.json
+++ b/openimis.json
@@ -101,10 +101,6 @@
 			"pip": "git+https://github.com/openimis/openimis-be-calcrule-third_party_payment_py.git@develop#egg=openimis-be-calcrule_third_party_payment"
 		},
 		{
-			"name": "calcrule_capitation_payment",
-			"pip": "git+https://github.com/openimis/openimis-be-calcrule-capitation_payment_py.git@develop#egg=openimis-be-calcrule-capitation_payment"
-		},
-		{
 			"name": "calcrule_commission",
 			"pip": "git+https://github.com/openimis/openimis-be-calcrule_commission_py.git@develop#egg=openimis-be-calcrule_commission"
 		},


### PR DESCRIPTION
Migration error after removing `calcrule_capitation_payment` module from `openimis.json`.

This error is connected to recent changes and fixes regarding the release, as the moldova project tests were migrating fine until about one week ago.

This error happens in `contribution_plan` `0001_squashed_0010_payment_plan_roles_for_admin` migration.

Possible explanation:
The `calcrule_capitation_payment` `0001_initial` migration fixes it by synchronizing the `location` and `product` migrations to both happen before `contribution_plan`. The `product` mutation is lazy bounded to `location` model and does not force the `location` mutation to happend before `product`. the `calcrule` migration depends both on `product` and `location` and is lexicographically sorted before the `contribution_plan`, fixing the problem

More tests required