### PR TITLE
Change default caching method to pymemecache

### DIFF
--- a/openIMIS/openIMIS/settings.py
+++ b/openIMIS/openIMIS/settings.py
@@ -389,11 +389,9 @@ CELERY_RESULT_BACKEND = os.environ.get("CELERY_BROKER_URL", "amqp://rabitmq")
 
 CACHES = {
     'default': {
-        'BACKEND': 'django_redis.cache.RedisCache',
-        'LOCATION': os.environ.get("CELERY_BROKER_URL", "amqp://rabitmq"),
-        'OPTIONS': {
-            'DB': 0
-        }
+        'BACKEND': os.environ.get('CACHE_BACKEND', 'django.core.cache.backends.memcached.PyMemcacheCache'),
+        'LOCATION': os.environ.get("CACHE_URL", "unix:/tmp/memcached.sock"),
+        'OPTIONS': json.loads(os.environ.get("CACHE_OPTIONS", "{}"))
     }
 }
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -51,3 +51,6 @@ nepali_datetime
 twisted>=23.10.0rc1 # not directly required, pinned by Snyk to avoid a vulnerability
 pillow>=10.2.0 # not directly required, pinned by Snyk to avoid a vulnerability
 
+django-redis==5.4.0
+django-opensearch-dsl==0.5.1
+pymemcache==4.0.0


### PR DESCRIPTION
Changes default caching option from redis to pymemecache that doesn't require additional setup outside the application. 