### PR TITLE
Fix grievance module URL for pip install

### DIFF
--- a/openimis.json
+++ b/openimis.json
@@ -153,8 +153,8 @@
 			"pip": "git+https://github.com/openimis/openimis-be-controls_py.git@develop#egg=openimis-be-controls"
 		},
 		{
-			"name": "grievance",
-			"pip": "git+https://github.com:openimis/openimis-be-grievance_social_protection_py.git@develop#egg=openimis-be-grievance_social_protection"
+			"name": "grievance_social_protection",
+			"pip": "git+https://github.com/openimis/openimis-be-grievance_social_protection_py.git@develop#egg=openimis-be-grievance_social_protection"
 		},
 		{
 			"name": "claim_sampling",


### PR DESCRIPTION
Also fix its package name so it can be loaded.

github workflow ci_assembly [fails](https://github.com/weilu/openimis-be_py/actions/runs/9753621211/job/26919185534) at the step of "Install Python dependencies" due to `fatal: unable to access 'https://github.com:openimis/openimis-be-grievance_social_protection_py.git/': URL using bad/illegal format or missing URL`. With changes in this PR it completes the "Install Python dependencies" step [successfully](https://github.com/weilu/openimis-be_py/actions/runs/9754191393/job/26920688469).