### PR TITLE
Fix dashboard_etl module not found issue

### DIFF
--- a/openIMIS/openIMIS/asgi.py
+++ b/openIMIS/openIMIS/asgi.py
@@ -1,5 +1,5 @@
 from channels.auth import AuthMiddlewareStack
-import dashboard_etl.routing
+# import dashboard_etl.routing
 import json
 import os
 import logging


### PR DESCRIPTION
Fix dashboard_etl module not found issue.

It looks like this import fail as the module 'dashboard_etl'  https://github.com/openimis/openimis-be-dashboard_etl_py is not present in the openimis.json file in 24.04 version.
