### PR TITLE
OP-2325: deleted TLS/SSL connection from allowed hosts

### DIFF
--- a/openIMIS/openIMIS/settings/dev.py
+++ b/openIMIS/openIMIS/settings/dev.py
@@ -4,12 +4,12 @@ EMAIL_BACKEND = 'django.core.mail.backends.console.EmailBackend'
 # Set ALLOWED_HOSTS
 ALLOWED_HOSTS = ['*']
 CSRF_TRUSTED_ORIGINS = [
-    'https://localhost',
-    'https://192.168.0.1',
-    'https://localhost:8000',
-    'https://192.168.0.1:8000',
-    'https://localhost:3000',
-    'https://192.168.0.1:3000',
+    'http://localhost',
+    'http://192.168.0.1',
+    'http://localhost:8000',
+    'http://192.168.0.1:8000',
+    'http://localhost:3000',
+    'http://192.168.0.1:3000',
 ]
 # Set CORS_ALLOWED_ORIGINS to match CSRF_TRUSTED_ORIGINS
 CORS_ALLOWED_ORIGINS = CSRF_TRUSTED_ORIGINS


### PR DESCRIPTION
Changes:
https://openimis.atlassian.net/browse/OP-2325

Changes:
- by default the dev.py used the TLS/SSL connection which resulted in unhandled error "no CSRF" when attempting to log into fresh instance

How was it tested?
- new instance was created
- allowed hosts were changed to not define the https connection