### PR TITLE
OSB-86: removed redundant configuration for AXES causing misleading output after unsucesfull login

### DIFF
--- a/openIMIS/openIMIS/settings/security.py
+++ b/openIMIS/openIMIS/settings/security.py
@@ -80,6 +80,7 @@ if os.path.exists(private_key_path) and os.path.exists(public_key_path):
 AXES_FAILURE_LIMIT = int(os.getenv("LOGIN_LOCKOUT_FAILURE_LIMIT", 5))
 AXES_COOLOFF_TIME = timedelta(minutes=int(os.getenv("LOGIN_LOCKOUT_COOLOFF_TIME", 5)))
 AXES_ENABLED = True if os.environ.get("AXES_ENABLED", "true").lower() == "true" else False
+AXES_CACHE = "default"
 
 RATELIMIT_CACHE = os.getenv('RATELIMIT_CACHE', 'default')
 RATELIMIT_KEY = os.getenv('RATELIMIT_KEY', 'ip')

--- a/openIMIS/openIMIS/settings/security.py
+++ b/openIMIS/openIMIS/settings/security.py
@@ -77,12 +77,9 @@ if os.path.exists(private_key_path) and os.path.exists(public_key_path):
 
 
 # Lockout mechanism configuration
-AXES_ENABLED = True if os.environ.get("MODE", "DEV") == "PROD" else False
 AXES_FAILURE_LIMIT = int(os.getenv("LOGIN_LOCKOUT_FAILURE_LIMIT", 5))
 AXES_COOLOFF_TIME = timedelta(minutes=int(os.getenv("LOGIN_LOCKOUT_COOLOFF_TIME", 5)))
-AXES_HANDLER = os.environ.get("AXES_HANDLER", 'axes.handlers.cache.AxesCacheHandler')
 AXES_ENABLED = True if os.environ.get("AXES_ENABLED", "true").lower() == "true" else False
-# AXES_LOCKOUT_PARAMETERS = ['username']
 
 RATELIMIT_CACHE = os.getenv('RATELIMIT_CACHE', 'default')
 RATELIMIT_KEY = os.getenv('RATELIMIT_KEY', 'ip')


### PR DESCRIPTION
TICKET: https://openimis.atlassian.net/browse/OS-86

Before change:
![Screenshot from 2025-02-25 12-41-30](https://github.com/user-attachments/assets/00bff8eb-94af-4891-872f-bf6c2b3ac51b)

After change: 
![Screenshot from 2025-02-25 12-40-56](https://github.com/user-attachments/assets/e2ff93b6-6477-439e-b627-16b533b5fad5)
