### PR TITLE
OSB-48: added django fixture init part

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -124,7 +124,7 @@
       "type": "python",
       "request": "launch",
       "program": "./setup-local-dev.py",
-      "args": ["extract_translations"],
+      "args": ["ssh"],
       "django": true,
       "cwd": "${workspaceRoot}/script",
       "purpose": ["debug-in-terminal"],

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,42 +1,57 @@
-FROM python:3.10-buster As builder
+FROM python:3.10-buster AS builder
 ENV PYTHONUNBUFFERED 1
 ARG DB_DEFAULT
 
-RUN apt-get update && apt-get install -y apt-transport-https ca-certificates gettext unixodbc-dev && apt-get upgrade -y
-RUN apt-get install -y -f python3-dev
-RUN apt-get -y install git
+# System dependencies
+RUN apt-get update && apt-get install -y \
+    apt-transport-https \
+    ca-certificates \
+    gettext \
+    unixodbc-dev \
+    python3-dev \
+    git \
+    jq \
+    && apt-get upgrade -y
 
+# MSSQL client (optional, depending on DB_DEFAULT)
 RUN test "$DB_DEFAULT" != "postgresql" && curl https://packages.microsoft.com/keys/microsoft.asc | apt-key add - || :
 RUN test "$DB_DEFAULT" != "postgresql" && curl https://packages.microsoft.com/config/debian/10/prod.list > /etc/apt/sources.list.d/mssql-release.list || :
 RUN test "$DB_DEFAULT" != "postgresql" && apt-get update || :
 RUN test "$DB_DEFAULT" != "postgresql" && ACCEPT_EULA=Y apt-get install -y msodbcsql17 mssql-tools18 || :
 
+# Python requirements
 RUN pip install --upgrade pip
-#RUN test "$DB_DEFAULT" != "postgresql" && pip install mssql-cli || :
-
 RUN pip install gunicorn
 
-FROM builder As app
+# Stage: App
+FROM builder AS app
 
-# Install requirements
+# Install Python dependencies
 COPY requirements.txt /.
 RUN pip install -r requirements.txt
 
+# Optional Sentry dependencies
 ARG SENTRY_DSN
 RUN test -z "$SENTRY_DSN" || pip install -r sentry-requirements.txt && :
 
+# Copy app source
 RUN mkdir /openimis-be
 COPY . /openimis-be
 WORKDIR /openimis-be
 
+# Environment for module parsing
 ARG OPENIMIS_CONF_JSON
 ENV OPENIMIS_CONF_JSON=${OPENIMIS_CONF_JSON}
-WORKDIR /openimis-be/script
-RUN python modules-requirements.py ../openimis.json > modules-requirements.txt && pip install -r modules-requirements.txt 
-WORKDIR /openimis-be/openIMIS
 
-# Compile messages (Exclude zh_Hans)
+# Install module-specific requirements
+WORKDIR /openimis-be/script
+RUN python modules-requirements.py ../openimis.json > modules-requirements.txt && pip install -r modules-requirements.txt
+
+# Collect static assets and messages
+WORKDIR /openimis-be/openIMIS
 RUN NO_DATABASE=True python manage.py compilemessages -x zh_Hans
 RUN NO_DATABASE=True python manage.py collectstatic --clear --noinput
 
+# Entrypoint
 ENTRYPOINT ["/openimis-be/script/entrypoint.sh"]
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -31,7 +31,7 @@ FROM builder AS app
 RUN mkdir /openimis-be
 COPY . /openimis-be
 WORKDIR /openimis-be
-RUN chmod a+x /openimis-be/script/entrypoint.sh
+RUN chmod a+x /openimis-be/script/entrypoint.sh /openimis-be/script/load_fixture.sh
 
 # Install requirements
 RUN pip install -r requirements.txt

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,16 +18,18 @@ RUN pip install gunicorn
 
 FROM builder As app
 
-# Install requirements
-COPY requirements.txt /.
-RUN pip install -r requirements.txt
 
-ARG SENTRY_DSN
-RUN test -z "$SENTRY_DSN" || pip install -r sentry-requirements.txt && :
 
 RUN mkdir /openimis-be
 COPY . /openimis-be
 WORKDIR /openimis-be
+RUN chmod a+x /openimis-be/script/entrypoint.sh
+
+# Install requirements
+RUN pip install -r requirements.txt
+
+ARG SENTRY_DSN
+RUN pip install -r sentry-requirements.txt
 
 ARG OPENIMIS_CONF_JSON
 ENV OPENIMIS_CONF_JSON=${OPENIMIS_CONF_JSON}

--- a/script/config.py
+++ b/script/config.py
@@ -1,0 +1,3 @@
+GITHUB_TOKEN=""
+USER_NAME=""
+BRANCH="develop"

--- a/script/entrypoint.sh
+++ b/script/entrypoint.sh
@@ -13,15 +13,16 @@ show_help() {
   manage           : run django manage.py
   eval             : eval shell command
   bash             : run bash
+  init             : initialize database
   """
 }
 
 init(){
-  if [ "${DJANGO_MIGRATE,,}" == "true" ] || [ -z "$SCHEDULER_AUTOSTART" ]; then
-        echo "Migrating..."
-        python manage.py migrate
-        export SCHEDULER_AUTOSTART=True
-  fi
+  echo "Migrating..."
+  python manage.py migrate
+  export SCHEDULER_AUTOSTART=True
+  echo "Running fixture loading script..."
+  bash ../script/load_fixture.sh
 }
 
 #export PYTHONPATH="/opt/app:$PYTHONPATH"
@@ -31,12 +32,10 @@ fi
 
 case "$1" in
   "start" )
-    init
     echo "Starting Django..."
     python server.py
   ;;
   "start_asgi" )
-    init
     echo "Starting Django ASGI..."
     def_ip='0.0.0.0'
     def_port='8000'
@@ -48,8 +47,11 @@ case "$1" in
 
     daphne -b "$SERVER_IP" -p "$SERVER_PORT" "$SERVER_APPLICATION"
   ;;
-  "start_wsgi" )
+  "init" )
     init
+    exit 0
+  ;;
+  "start_wsgi" )
     echo "Starting Django WSGI..."
     def_ip='0.0.0.0'
     def_port='8000'

--- a/script/entrypoint.sh
+++ b/script/entrypoint.sh
@@ -5,7 +5,6 @@ show_help() {
   echo """
   Commands
   ---------------------------------------------------------------
-
   start            : start django
   worker           : start Celery worker
   start_asgi       : use daphne -b ASGI_IP:WSGI_PORT -p SERVER_PORT  ASGI_APPLICATION
@@ -16,15 +15,55 @@ show_help() {
   """
 }
 
-init(){
-  if [ "${DJANGO_MIGRATE,,}" == "true" ] || [ -z "$SCHEDULER_AUTOSTART" ]; then
-        echo "Migrating..."
-        python manage.py migrate
-        export SCHEDULER_AUTOSTART=True
+load_fixtures_if_needed() {
+  echo "Checking and loading optional fixtures..."
+
+  FIXTURE_PATH=/openimis-be/initialization
+  SOLUTIONS_PATH=$FIXTURE_PATH/solutions
+
+  if [ ! -d "$SOLUTIONS_PATH" ]; then
+    echo "Cloning openIMIS solutions repo..."
+    mkdir -p "$FIXTURE_PATH"
+    git clone --depth 1 https://github.com/openimis/solutions.git "$SOLUTIONS_PATH"
   fi
+
+  if [[ "$FIXTURE_INIT" == "true" ]]; then
+    echo "Fixture init enabled..."
+
+    FIXTURE_SETS=(
+      "coreMIS/fixtures/locations.json"
+      "coreMIS/fixtures/education.json"
+      "coreMIS/fixtures/health_facilities.json"
+      "sphf/fixtures/sphf_indicator.json"
+    )
+
+    for f in "${FIXTURE_SETS[@]}"; do
+      name=$(basename "$f" .json)
+      echo "Checking if table for fixture $name is empty..."
+      count=$(python manage.py dumpdata "$name" 2>/dev/null | jq length || echo 0)
+      if [[ "$count" -eq 0 ]]; then
+        echo "Loading fixture: $f"
+        python manage.py loaddata "$SOLUTIONS_PATH/$f"
+      else
+        echo "Skipping $name: table not empty."
+      fi
+    done
+  fi
+
+  echo "Loading roles-right with foreign key support..."
+  python manage.py load_fixture_foreign_key "$SOLUTIONS_PATH/coreMIS/fixtures/core/roles-right.json" uuid
 }
 
-#export PYTHONPATH="/opt/app:$PYTHONPATH"
+init() {
+  if [ "${DJANGO_MIGRATE,,}" == "true" ] || [ -z "$SCHEDULER_AUTOSTART" ]; then
+    echo "Running Django migrations..."
+    python manage.py migrate
+    export SCHEDULER_AUTOSTART=True
+  fi
+
+  load_fixtures_if_needed
+}
+
 if [ -z "$DJANGO_SETTINGS_MODULE" ]; then
   export DJANGO_SETTINGS_MODULE=openIMIS.settings
 fi
@@ -38,29 +77,12 @@ case "$1" in
   "start_asgi" )
     init
     echo "Starting Django ASGI..."
-    def_ip='0.0.0.0'
-    def_port='8000'
-    def_app='openIMIS.asgi:application'
-
-    SERVER_IP="${ASGI_IP:-$def_ip}"
-    SERVER_PORT="${ASGI_PORT:-$def_port}"
-    SERVER_APPLICATION="${ASGI_APPLICATION:-$def_app}"
-
-    daphne -b "$SERVER_IP" -p "$SERVER_PORT" "$SERVER_APPLICATION"
+    daphne -b "${ASGI_IP:-0.0.0.0}" -p "${ASGI_PORT:-8000}" "${ASGI_APPLICATION:-openIMIS.asgi:application}"
   ;;
   "start_wsgi" )
     init
     echo "Starting Django WSGI..."
-    def_ip='0.0.0.0'
-    def_port='8000'
-    def_app='openIMIS.wsgi'
-
-    SERVER_IP="${WSGI_IP:-$def_ip}"
-    SERVER_PORT="${WSGI_PORT:-$def_port}"
-    SERVER_APPLICATION="${WSGI_APPLICATION:-$def_app}"
-    SERVER_WORKERS="${WSGI_WORKERS:-4}"
-
-    gunicorn -b "$SERVER_IP:$SERVER_PORT" -w $SERVER_WORKERS "$SERVER_APPLICATION"
+    gunicorn -b "${WSGI_IP:-0.0.0.0}:${WSGI_PORT:-8000}" -w "${WSGI_WORKERS:-4}" "${WSGI_APPLICATION:-openIMIS.wsgi}"
   ;;
   "worker" )
     echo "Starting Celery with url ${CELERY_BROKER_URL} ${DB_NAME}..."

--- a/script/entrypoint.sh
+++ b/script/entrypoint.sh
@@ -27,46 +27,46 @@ load_fixtures_if_needed() {
   
   echo "=== Fixture loading test for solution: $SOLUTION_NAME ==="
 
-# Clone if solution folder doesn't exist
-if [ ! -d "$SOLUTION_PATH" ]; then
-  echo "Cloning openIMIS solutions repo and extracting '$SOLUTION_NAME'..."
-  mkdir -p "$FIXTURE_PATH"
-  git clone --depth 1 https://github.com/openimis/solutions.git "$FIXTURE_PATH/tmp_solutions"
+  # Clone if solution folder doesn't exist
+  if [ ! -d "$SOLUTION_PATH" ]; then
+    echo "Cloning openIMIS solutions repo and extracting '$SOLUTION_NAME'..."
+    mkdir -p "$FIXTURE_PATH"
+    git clone --depth 1 https://github.com/openimis/solutions.git "$FIXTURE_PATH/tmp_solutions"
 
-  if [ ! -d "$FIXTURE_PATH/tmp_solutions/$SOLUTION_NAME" ]; then
-    echo "Solution '$SOLUTION_NAME' not found in solutions repo."
-    exit 2
+    if [ ! -d "$FIXTURE_PATH/tmp_solutions/$SOLUTION_NAME" ]; then
+      echo "Solution '$SOLUTION_NAME' not found in solutions repo."
+      exit 2
+    fi
+
+    mv "$FIXTURE_PATH/tmp_solutions/$SOLUTION_NAME" "$SOLUTION_PATH"
+    rm -rf "$FIXTURE_PATH/tmp_solutions"
   fi
 
-  mv "$FIXTURE_PATH/tmp_solutions/$SOLUTION_NAME" "$SOLUTION_PATH"
-  rm -rf "$FIXTURE_PATH/tmp_solutions"
-fi
+  # Load all fixtures (except roles-right.json)
+  FIXTURE_FILES=$(find "$FIXTURE_DIR" -type f -name "*.json" ! -name "roles-right.json")
 
-# Load all fixtures (except roles-right.json)
-FIXTURE_FILES=$(find "$FIXTURE_DIR" -type f -name "*.json" ! -name "roles-right.json")
+  for f in $FIXTURE_FILES; do
+    name=$(basename "$f" .json)
+    echo "Checking if table for fixture '$name' is empty..."
+    count=$(python manage.py dumpdata "$name" 2>/dev/null | jq length || echo 0)
 
-for f in $FIXTURE_FILES; do
-  name=$(basename "$f" .json)
-  echo "Checking if table for fixture '$name' is empty..."
-  count=$(python manage.py dumpdata "$name" 2>/dev/null | jq length || echo 0)
+    if [[ "$count" -eq 0 ]]; then
+      echo "Loading fixture: $f"
+      python manage.py loaddata "$f"
+    else
+      echo "Skipping $name: table not empty."
+    fi
+  done
 
-  if [[ "$count" -eq 0 ]]; then
-    echo "Loading fixture: $f"
-    python manage.py loaddata "$f"
+  # Load roles-right fixture
+  if [ -f "$FIXTURE_DIR/roles-right.json" ]; then
+    echo "Loading roles-right fixture with foreign key support..."
+    python manage.py load_fixture_foreign_key "$FIXTURE_DIR/roles-right.json" uuid
   else
-    echo "Skipping $name: table not empty."
+    echo "roles-right.json not found in $FIXTURE_DIR. Skipping."
   fi
-done
 
-# Load roles-right fixture
-if [ -f "$FIXTURE_DIR/roles-right.json" ]; then
-  echo "Loading roles-right fixture with foreign key support..."
-  python manage.py load_fixture_foreign_key "$FIXTURE_DIR/roles-right.json" uuid
-else
-  echo "roles-right.json not found in $FIXTURE_DIR. Skipping."
-fi
-
-echo "=== Fixture test complete for $SOLUTION_NAME ==="
+  echo "=== Fixture test complete for $SOLUTION_NAME ==="
 }
 
 init() {

--- a/script/entrypoint.sh
+++ b/script/entrypoint.sh
@@ -18,42 +18,55 @@ show_help() {
 load_fixtures_if_needed() {
   echo "Checking and loading optional fixtures..."
 
-  FIXTURE_PATH=/openimis-be/initialization
-  SOLUTIONS_REPO=https://github.com/openimis/solutions.git
-  SOLUTIONS_PATH=$FIXTURE_PATH/solutions
-  FLATTENED_FIXTURES_PATH=$SOLUTIONS_PATH/fixtures
+  SOLUTION_NAME="${FIXTURE_SOLUTION:-coreMIS}"
 
-  # Clone solutions repo if missing
-  if [ ! -d "$SOLUTIONS_PATH" ]; then
-    echo "Cloning openIMIS solutions repo..."
-    mkdir -p "$FIXTURE_PATH"
-    git clone --depth 1 "$SOLUTIONS_REPO" "$SOLUTIONS_PATH"
+  # Configuration
+  FIXTURE_PATH="./initialization"
+  SOLUTION_PATH="$FIXTURE_PATH/$SOLUTION_NAME"
+  FIXTURE_DIR="$SOLUTION_PATH/fixtures"
+  
+  echo "=== Fixture loading test for solution: $SOLUTION_NAME ==="
+
+# Clone if solution folder doesn't exist
+if [ ! -d "$SOLUTION_PATH" ]; then
+  echo "Cloning openIMIS solutions repo and extracting '$SOLUTION_NAME'..."
+  mkdir -p "$FIXTURE_PATH"
+  git clone --depth 1 https://github.com/openimis/solutions.git "$FIXTURE_PATH/tmp_solutions"
+
+  if [ ! -d "$FIXTURE_PATH/tmp_solutions/$SOLUTION_NAME" ]; then
+    echo "Solution '$SOLUTION_NAME' not found in solutions repo."
+    exit 2
   fi
 
-  # Flatten all fixture files into one folder
-  echo "Collecting and flattening fixture files..."
-  mkdir -p "$FLATTENED_FIXTURES_PATH"
-  find "$SOLUTIONS_PATH" -type f -path "*/fixtures/*.json" ! -name "roles-right.json" | while read -r f; do
-    cp "$f" "$FLATTENED_FIXTURES_PATH/$(basename "$f")"
-  done
+  mv "$FIXTURE_PATH/tmp_solutions/$SOLUTION_NAME" "$SOLUTION_PATH"
+  rm -rf "$FIXTURE_PATH/tmp_solutions"
+fi
 
-  if [[ "$FIXTURE_INIT" == "true" ]]; then
-    echo "Fixture init enabled..."
-    for fixture in "$FLATTENED_FIXTURES_PATH"/*.json; do
-      name=$(basename "$fixture" .json)
-      echo "Checking if table for fixture '$name' is empty..."
-      count=$(python manage.py dumpdata "$name" 2>/dev/null | jq length || echo 0)
-      if [[ "$count" -eq 0 ]]; then
-        echo "Loading fixture: $fixture"
-        python manage.py loaddata "$fixture"
-      else
-        echo "Skipping $name: table not empty."
-      fi
-    done
+# Load all fixtures (except roles-right.json)
+FIXTURE_FILES=$(find "$FIXTURE_DIR" -type f -name "*.json" ! -name "roles-right.json")
+
+for f in $FIXTURE_FILES; do
+  name=$(basename "$f" .json)
+  echo "Checking if table for fixture '$name' is empty..."
+  count=$(python manage.py dumpdata "$name" 2>/dev/null | jq length || echo 0)
+
+  if [[ "$count" -eq 0 ]]; then
+    echo "Loading fixture: $f"
+    python manage.py loaddata "$f"
+  else
+    echo "Skipping $name: table not empty."
   fi
+done
 
-  echo "Loading roles-rights fixture with foreign key support..."
-  python manage.py load_fixture_foreign_key "$FLATTENED_FIXTURES_PATH/roles-right.json" uuid
+# Load roles-right fixture
+if [ -f "$FIXTURE_DIR/roles-right.json" ]; then
+  echo "Loading roles-right fixture with foreign key support..."
+  python manage.py load_fixture_foreign_key "$FIXTURE_DIR/roles-right.json" uuid
+else
+  echo "roles-right.json not found in $FIXTURE_DIR. Skipping."
+fi
+
+echo "=== Fixture test complete for $SOLUTION_NAME ==="
 }
 
 init() {

--- a/script/entrypoint.sh
+++ b/script/entrypoint.sh
@@ -5,6 +5,7 @@ show_help() {
   echo """
   Commands
   ---------------------------------------------------------------
+
   start            : start django
   worker           : start Celery worker
   start_asgi       : use daphne -b ASGI_IP:WSGI_PORT -p SERVER_PORT  ASGI_APPLICATION
@@ -15,69 +16,19 @@ show_help() {
   """
 }
 
-load_fixtures_if_needed() {
-  echo "Checking and loading optional fixtures..."
-
-  SOLUTION_NAME="${FIXTURE_SOLUTION:-coreMIS}"
-
-  # Configuration
-  FIXTURE_PATH="./initialization"
-  SOLUTION_PATH="$FIXTURE_PATH/$SOLUTION_NAME"
-  FIXTURE_DIR="$SOLUTION_PATH/fixtures"
-  
-  echo "=== Fixture loading test for solution: $SOLUTION_NAME ==="
-
-  # Clone if solution folder doesn't exist
-  if [ ! -d "$SOLUTION_PATH" ]; then
-    echo "Cloning openIMIS solutions repo and extracting '$SOLUTION_NAME'..."
-    mkdir -p "$FIXTURE_PATH"
-    git clone --depth 1 https://github.com/openimis/solutions.git "$FIXTURE_PATH/tmp_solutions"
-
-    if [ ! -d "$FIXTURE_PATH/tmp_solutions/$SOLUTION_NAME" ]; then
-      echo "Solution '$SOLUTION_NAME' not found in solutions repo."
-      exit 2
-    fi
-
-    mv "$FIXTURE_PATH/tmp_solutions/$SOLUTION_NAME" "$SOLUTION_PATH"
-    rm -rf "$FIXTURE_PATH/tmp_solutions"
-  fi
-
-  # Load all fixtures (except roles-right.json)
-  FIXTURE_FILES=$(find "$FIXTURE_DIR" -type f -name "*.json" ! -name "roles-right.json")
-
-  for f in $FIXTURE_FILES; do
-    name=$(basename "$f" .json)
-    echo "Checking if table for fixture '$name' is empty..."
-    count=$(python manage.py dumpdata "$name" 2>/dev/null | jq length || echo 0)
-
-    if [[ "$count" -eq 0 ]]; then
-      echo "Loading fixture: $f"
-      python manage.py loaddata "$f"
-    else
-      echo "Skipping $name: table not empty."
-    fi
-  done
-
-  # Load roles-right fixture
-  if [ -f "$FIXTURE_DIR/roles-right.json" ]; then
-    echo "Loading roles-right fixture with foreign key support..."
-    python manage.py load_fixture_foreign_key "$FIXTURE_DIR/roles-right.json" uuid
-  else
-    echo "roles-right.json not found in $FIXTURE_DIR. Skipping."
-  fi
-
-  echo "=== Fixture test complete for $SOLUTION_NAME ==="
-}
-
-init() {
+init(){
   if [ "${DJANGO_MIGRATE,,}" == "true" ] || [ -z "$SCHEDULER_AUTOSTART" ]; then
-    echo "Running Django migrations..."
-    python manage.py migrate
-    export SCHEDULER_AUTOSTART=True
-    load_fixtures_if_needed
+        echo "Migrating..."
+        python manage.py migrate
+        export SCHEDULER_AUTOSTART=True
+        echo "Ensuring load_fixture.sh is executable..."
+        chmod +x ./load_fixture.sh
+        echo "Running fixture loading script..."
+        ./load_fixture.sh
   fi
 }
 
+#export PYTHONPATH="/opt/app:$PYTHONPATH"
 if [ -z "$DJANGO_SETTINGS_MODULE" ]; then
   export DJANGO_SETTINGS_MODULE=openIMIS.settings
 fi
@@ -91,12 +42,29 @@ case "$1" in
   "start_asgi" )
     init
     echo "Starting Django ASGI..."
-    daphne -b "${ASGI_IP:-0.0.0.0}" -p "${ASGI_PORT:-8000}" "${ASGI_APPLICATION:-openIMIS.asgi:application}"
+    def_ip='0.0.0.0'
+    def_port='8000'
+    def_app='openIMIS.asgi:application'
+
+    SERVER_IP="${ASGI_IP:-$def_ip}"
+    SERVER_PORT="${ASGI_PORT:-$def_port}"
+    SERVER_APPLICATION="${ASGI_APPLICATION:-$def_app}"
+
+    daphne -b "$SERVER_IP" -p "$SERVER_PORT" "$SERVER_APPLICATION"
   ;;
   "start_wsgi" )
     init
     echo "Starting Django WSGI..."
-    gunicorn -b "${WSGI_IP:-0.0.0.0}:${WSGI_PORT:-8000}" -w "${WSGI_WORKERS:-4}" "${WSGI_APPLICATION:-openIMIS.wsgi}"
+    def_ip='0.0.0.0'
+    def_port='8000'
+    def_app='openIMIS.wsgi'
+
+    SERVER_IP="${WSGI_IP:-$def_ip}"
+    SERVER_PORT="${WSGI_PORT:-$def_port}"
+    SERVER_APPLICATION="${WSGI_APPLICATION:-$def_app}"
+    SERVER_WORKERS="${WSGI_WORKERS:-4}"
+
+    gunicorn -b "$SERVER_IP:$SERVER_PORT" -w $SERVER_WORKERS "$SERVER_APPLICATION"
   ;;
   "worker" )
     echo "Starting Celery with url ${CELERY_BROKER_URL} ${DB_NAME}..."

--- a/script/load_fixture.sh
+++ b/script/load_fixture.sh
@@ -1,0 +1,68 @@
+#!/bin/bash
+set -e
+
+# Use env var or default to 'openimis'
+SOLUTION_NAME="${FIXTURE_SOLUTION:-openIMIS}"
+
+# Configuration
+
+FIXTURE_PATH="./initialization"
+SOLUTION_PATH="$FIXTURE_PATH/$SOLUTION_NAME"
+FIXTURE_DIR="$SOLUTION_PATH/fixtures"
+
+echo "=== Fixture loading test for solution: $SOLUTION_NAME ==="
+
+# Clone if solution folder doesn't exist
+if [ ! -d "$SOLUTION_PATH" ]; then
+  echo "Cloning openIMIS solutions repo and extracting '$SOLUTION_NAME'..."
+  mkdir -p "$FIXTURE_PATH"
+  git clone --depth 1 https://github.com/openimis/solutions.git "$FIXTURE_PATH/tmp_solutions"
+
+  if [ ! -d "$FIXTURE_PATH/tmp_solutions/$SOLUTION_NAME" ]; then
+    echo "Solution '$SOLUTION_NAME' not found in solutions repo."
+    exit 2
+  fi
+
+  mv "$FIXTURE_PATH/tmp_solutions/$SOLUTION_NAME" "$SOLUTION_PATH"
+  rm -rf "$FIXTURE_PATH/tmp_solutions"
+fi
+
+for fixture_file in "$FIXTURE_DIR"/*.json; do
+  name=$(basename "$fixture_file")
+  model=$(jq -r '.[0].model' "$fixture_file" 2>/dev/null)
+
+  if [[ -z "$model" || "$model" == "null" ]]; then
+    echo "⚠️  Skipping $name: couldn't determine model."
+    continue
+  fi
+
+  echo "🔍 Checking model: $model from $name"
+
+  count=$(python ../openIMIS/manage.py shell -c "from ${model%.*} import ${model#*.} as M; print(M.objects.count())" 2>/dev/null || echo 0)
+
+  if [[ "$count" -eq 0 ]]; then
+    echo "✅ Loading fixture: $fixture_file"
+    python ../openIMIS/manage.py loaddata "$fixture_file"
+  else
+    echo "⏩ Skipping $model ($name): table not empty ($count records)."
+  fi
+done
+
+# Load roles-right fixture
+if [ -f "$FIXTURE_DIR/roles-right.json" ]; then
+  echo "Loading roles-right fixture with foreign key support..."
+
+  echo "Checking if table for fixture RoleRight is empty"
+  count=$(python ../openIMIS/manage.py shell -c "from core import RoleRight as M; print(M.objects.count())" 2>/dev/null || echo 0)
+
+  if [[ "$count" -eq 0 ]]; then
+    echo "Loading roles-right.json fixture..."
+    python ../openIMIS/manage.py load_fixture_foreign_key "$FIXTURE_DIR/roles-right.json" --field name
+  else
+    echo "Skipping roles-right.json: RoleRight table not empty ($count records)."
+  fi
+else
+  echo "roles-right.json not found in $FIXTURE_DIR. Skipping."
+fi
+
+echo "=== Fixture test complete for $SOLUTION_NAME ==="

--- a/script/setup-local-dev.py
+++ b/script/setup-local-dev.py
@@ -7,10 +7,15 @@ from github import Github  # pip install pyGithub
 import sys
 from all_requirements import install_modules
 ref_assembly = BRANCH#"develop"
-
+MODE = None
+if len(sys.argv) > 1:
+    MODE = sys.argv[1]
 
 def main():
-    g = Github(GITHUB_TOKEN)
+    if GITHUB_TOKEN:
+        g = Github(GITHUB_TOKEN)
+    else: # Anonymous
+        g = Github()
     # assembly_fe='openimis/openimis-fe_js'
     assembly_be = "openimis/openimis-be_py"
     # refresh openimis.json from git
@@ -28,11 +33,20 @@ def main():
 
 
 
+def get_remote(repo, mode = None):
+    if mode == 'ssh':
+        remote = f"git@github.com:openimis/openimis-be_py.git"
+    elif GITHUB_TOKEN:
+        remote = f"https://{USER_NAME}:{GITHUB_TOKEN}@{repo.git_url[6:]}"
+    else:
+        remote = f"https://{repo.git_url[6:]}"
+    return remote
 
 def clone_repo(repo, module_name, ref='develop'):
-    src_path = os.path.abspath("../src/")
+    src_path = os.path.abspath("../../")
     path = os.path.join(src_path, module_name)
-    remote = f"https://{USER_NAME}:{GITHUB_TOKEN}@{repo.git_url[6:]}"
+    remote = get_remote(repo, MODE)
+
     if os.path.exists(path):
         repo_git = git.Repo(path)
         try:

--- a/script/utils.py
+++ b/script/utils.py
@@ -1,7 +1,8 @@
 import re
 
 def parse_pip(pip_str):
-    if "https://github.com" in pip_str:
+    match = re.search(r'github.com/(.+).git', pip_str )
+    if match:
         match = re.search(r'github.com/(.+).git', pip_str )
         return match.group(1)
     else:
@@ -9,8 +10,8 @@ def parse_pip(pip_str):
 
      
 def parse_pip_branch(pip_str):
-    if "https://github.com" in pip_str:
-        match = re.search(r'github.com/.+.git@([\w_\-\/\.]+).*',pip_str )
+    match = re.search(r'github.com/.+.git@([\w_\-\/\.]+).*',pip_str )
+    if match:
         return match.group(1)
     else:
         print("Error branch not found")
@@ -18,11 +19,13 @@ def parse_pip_branch(pip_str):
 
   
 def parse_npm(npm_str):
-    if "https://github.com" in npm_str:
-        match = re.search(r'github.com/(.+).git',npm_str )
+    match = re.search(r'github.com/(.+).git',npm_str )
+    if match:
         return match.group(1)
     else:
         match = re.search(r'@openimis/(.+)@',npm_str )
+        if match:
+            return match.group(1)
     
     
 def walk_config_be(g,be, callback):


### PR DESCRIPTION
TICKET: https://openimis.atlassian.net/browse/OSB-48

How it works: 
1. After 'migration' in 'init' mode there is a trigger to run loading fixtures from file `load_fixture.sh`
2. Script can be run also as a standalone one by having installed env for openIMIS (and all other configurations to run locally) and using: `./load_fixture.sh`
3. It works only if given table is empty! 

@delcroip Please check this on your end and confirm if it works for you or not. Let me know if you face any issues. 