### PR TITLE
Fix BASE_DIR path resolution after settings module restructure

### DIFF
--- a/openIMIS/openIMIS/settings/common.py
+++ b/openIMIS/openIMIS/settings/common.py
@@ -2,7 +2,7 @@ import os
 import sys
 
 # Build paths inside the project like this: os.path.join(BASE_DIR, ...)
-BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+BASE_DIR = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
 MODE = os.environ.get("MODE", 'prod').lower()
 if MODE == "dev" or "test" in sys.argv:

--- a/openIMIS/openIMIS/settings/common.py
+++ b/openIMIS/openIMIS/settings/common.py
@@ -1,8 +1,9 @@
 import os
 import sys
+from pathlib import Path
 
 # Build paths inside the project like this: os.path.join(BASE_DIR, ...)
-BASE_DIR = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+BASE_DIR = Path(__file__).absolute().parent.parent.parent
 
 MODE = os.environ.get("MODE", 'prod').lower()
 if MODE == "dev" or "test" in sys.argv:


### PR DESCRIPTION
Due to the restructuring of Django settings into a module/folder, the BASE_DIR path was shifted one level deeper, resulting in incorrect file lookups in certain management commands. This PR corrects the BASE_DIR calculation to ensure commands continue working as expected.

Please review and let me know if there are other areas potentially affected by this change.