### PR TITLE
fix: count existing record code correciton

### DIFF
--- a/script/load_fixture.sh
+++ b/script/load_fixture.sh
@@ -47,9 +47,12 @@ if [ -d "$FIXTURE_DIR" ]; then
       fi
 
       echo "🔍 Checking model: $model from $name"
-
-      count=$(python ../openIMIS/manage.py shell -c "from ${model%.*} import ${model#*.} as M; print(M.objects.count())" 2>/dev/null || echo 0)
-
+      
+      model_class="${model#*.}"
+      model_class_cap="${model_class^}"
+      output=$(python ../openIMIS/manage.py shell -c "from django.apps import apps; M = apps.get_model('$model'); print(M.objects.count())")
+      count=$(echo "$output" | grep -E '^[0-9]+$' | tail -1)
+      if [[ -z "$count" ]]; then count=0; fi
       if [[ "$count" -eq 0 ]]; then
         echo "✅ Loading fixture: $fixture_file"
         if [ "$name" = "roles-right.json" ]; then


### PR DESCRIPTION
result of that script for SR solution on s1 server

```
migrations-1  | Running fixture loading script...
migrations-1  | === Fixture loading test for solution: openIMIS ===
migrations-1  | 🔍 Checking model: core.language from core_language.json
migrations-1  | ⏩ Skipping core.language (core_language.json): table not empty (2 records).
migrations-1  | 🔍 Checking model: core.role from core_role.json
migrations-1  | ⏩ Skipping core.role (core_role.json): table not empty (14 records).
migrations-1  | 🔍 Checking model: core.roleright from core_roleright.json
migrations-1  | ⏩ Skipping core.roleright (core_roleright.json): table not empty (391 records).
migrations-1  | 🔍 Checking model: insuree.confirmationtype from insuree_confirmationtype.json
migrations-1  | ⏩ Skipping insuree.confirmationtype (insuree_confirmationtype.json): table not empty (4 records).
migrations-1  | 🔍 Checking model: insuree.education from insuree_education.json
migrations-1  | ⏩ Skipping insuree.education (insuree_education.json): table not empty (7 records).
migrations-1  | 🔍 Checking model: insuree.familytype from insuree_familytype.json
migrations-1  | ⏩ Skipping insuree.familytype (insuree_familytype.json): table not empty (7 records).
migrations-1  | 🔍 Checking model: insuree.gender from insuree_gender.json
migrations-1  | ⏩ Skipping insuree.gender (insuree_gender.json): table not empty (3 records).
migrations-1  | 🔍 Checking model: insuree.identificationtype from insuree_identificationtype.json
migrations-1  | ⏩ Skipping insuree.identificationtype (insuree_identificationtype.json): table not empty (4 records).
migrations-1  | 🔍 Checking model: insuree.profession from insuree_profession.json
migrations-1  | ⏩ Skipping insuree.profession (insuree_profession.json): table not empty (4 records).
migrations-1  | 🔍 Checking model: insuree.relation from insuree_relation.json
migrations-1  | ⏩ Skipping insuree.relation (insuree_relation.json): table not empty (8 records).
migrations-1  | 🔍 Checking model: core.moduleconfiguration from module-configuration-core.json
migrations-1  | ✅ Loading fixture: ../fixtures/module-configuration-core.json
migrations-1  | Load cfg {'location_types': ['R', 'D', 'W', 'V'], 'gql_query_locations_perms': ['121901'], 'gql_query_health_facilities_perms': ['121101'], 'gql_mutation_create_locations_perms': ['121902'], 'gql_mutation_edit_locations_perms': ['121903'], 'gql_mutation_delete_locations_perms': ['121904'], 'gql_mutation_move_location_perms': ['121905'], 'gql_mutation_create_region_locations_perms': ['121906'], 'gql_mutation_create_health_facilities_perms': ['121102'], 'gql_mutation_edit_health_facilities_perms': ['121103'], 'gql_mutation_delete_health_facilities_perms': ['121104'], 'no_location_check': False, 'health_facility_level': [{'code': 'D', 'display': 'Dispensary'}, {'code': 'C', 'display': 'Health Centre'}, {'code': 'H', 'display': 'Hospital'}], 'health_facility_contract_dates_mandatory': False}
migrations-1  | Installed 1 object(s) from 1 fixture(s)
migrations-1  | === Fixture test complete for openIMIS ===
```
fixture mounted on the migrations service:
```
  migrations:
    image: ghcr.io/openimis/openimis-be:${BE_TAG:-develop}
    environment: *ref_0
    volumes:
     - ./fixtures:/openimis-be/fixtures

```

fixture were loaded from the solution repo: https://github.com/openimis/solutions/tree/solution/SR/20250716/SR/fixtures

