### PR TITLE
Removed except blocks that fails silently if any error occurs in schema load

### DIFF
--- a/openIMIS/openIMIS/schema.py
+++ b/openIMIS/openIMIS/schema.py
@@ -31,11 +31,6 @@ for app in all_apps:
         pass
         # The module doesn't have a schema.py, just skip
         #logger.debug(f"{app} has no schema module, skipping")
-    except AttributeError as exc:
-        logger.debug(f"{app} queries couldn't be loaded")
-        raise  # This can be hiding actual compilation errors
-    except Exception as exc:
-        logger.debug(f"{app} exception", exc)
 
     try:
         schema_module = __import__(f"{app}.schema")
@@ -49,9 +44,6 @@ for app in all_apps:
     except ModuleNotFoundError as exc:
         # The module doesn't have a schema.py, just skip
         logger.debug(f"{app} has no schema module (mutation), skipping")
-    except AttributeError as exc:
-        # The module doesn't have a Query or Mutation, just ignore
-        logger.debug(f"{app} has a schema module and Mutation but failed nonetheless")
 
     for binder in bind_signals:
         binder()


### PR DESCRIPTION
This PR removes the silent except block that was previously masking important errors during the schema compilation phase. The earlier implementation suppressed exceptions without any visibility(only visible in debug logs), causing modules with critical issues to fail silently. As a result, the project continued to run while quietly excluding the affected modules, making it difficult to detect and diagnose the underlying problems.

By removing this silent exception handling, any errors encountered during schema loading will now be clearly visible. This improves overall transparency during module initialization and ensures that compilation or import issues are caught early, rather than being overlooked. This change will help developers identify problematic modules immediately, address failures at their source, and maintain a more reliable and predictable runtime environment.