### PR TITLE
Add HistoryRequestMiddleware to middleware settings

### DIFF
--- a/openIMIS/openIMIS/settings/base.py
+++ b/openIMIS/openIMIS/settings/base.py
@@ -120,6 +120,7 @@ MIDDLEWARE = [
     "django.middleware.common.CommonMiddleware",
     "django.middleware.csrf.CsrfViewMiddleware",
     "django.contrib.auth.middleware.AuthenticationMiddleware",
+    "simple_history.middleware.HistoryRequestMiddleware",
     "core.middleware.SecurityHeadersMiddleware",
     "csp.middleware.CSPMiddleware",
 ]


### PR DESCRIPTION
# Description

get_current_user will be removed from the save on , the approach will be more aligned with how  with how django-simple-history should work https://django-simple-history.readthedocs.io/en/stable/user_tracking.html

# Type of Change

- [ ] Feature
- [ ] Bug fix
- [x ] Chore (Refactor, Docs, CI/CD)
- [ ] Other, please specify

## Related Issue(s) / Task(s)

- [ ] Relates to https://github.com/pulls?q=is%3Apr+is%3Aopen+draft%3Afalse+org%3Aopenimis+head%3Afeature%2Ftest-empty-db&referrer=grok.com
- [ ] External reference (e.g., Jira):
