### PR TITLE
Fix: add timesheet calcrule to openimis.json [OP-2997]

### DIFF
--- a/openimis.json
+++ b/openimis.json
@@ -149,6 +149,10 @@
             "pip": "git+https://github.com/openimis/openimis-be-calcrule_social_protection_py.git@develop#egg=openimis-be-calcrule_social_protection"
         },
         {
+            "name": "calcrule_timesheet",
+            "pip": "git+https://github.com/openimis/openimis-be-calcrule_timesheet_py.git@develop#egg=openimis-be-calcrule_timesheet"
+        },
+        {
             "name": "payroll",
             "pip": "git+https://github.com/openimis/openimis-be-payroll_py.git@develop#egg=openimis-be-payroll"
         },


### PR DESCRIPTION
# Description

Add timesheet calcrule module to openimis.json so it appears as a calculation rule in the dropdown list when creating a payment plan.

# Type of Change

- [ ] Feature
- [x] Bug fix
- [ ] Chore (Refactor, Docs, CI/CD)
- [ ] Other, please specify

## Related Issue(s) / Task(s)
- [ ] Requires [link to github PR], [link to github PR] needs to be merged first before this one
- [ ] Relates to [link to github PR], this needs to be merged before [link to github PR]
- [x] External reference (e.g., Jira): https://openimis.atlassian.net/browse/OP-2997

## Demo

Upload screenshots/gifs or link to any demo video here.

## Checklist
- [ ] Unit tests added/modified
- [ ] I18n / translation handled
