### PR TITLE
chore: coordinate test-suite fixes across 5 modules

### DIFF
--- a/.github/workflows/ci_assembly.yml
+++ b/.github/workflows/ci_assembly.yml
@@ -102,6 +102,9 @@ jobs:
           git clone  --depth=1 --branch=$DBBRANCH https://github.com/openimis/database_postgresql.git ./sql_psql
           sudo bash ./sql_psql/install_postgres_json_schema_extension.sh
           echo 'set search_path to public' >> ~/.psqlrc
+          # The pgsql service container creates test_imis (POSTGRES_DB=test_imis) but not imis.
+          # Django requires the main DB (imis) to exist at startup, even with --keepdb.
+          PGPASSWORD=$DB_PASSWORD psql -U $DB_USER -h $DB_HOST -d postgres -c "CREATE DATABASE $DB_NAME;" || true
           PGPASSWORD=YourStrong!Passw0rd psql -U $DB_USER -h $DB_HOST -d $DB_NAME_TEST -f  ./sql_psql/database\ scripts/json_schema_extension.sql | grep . | uniq -c
         env:
           DB_HOST: localhost

--- a/openimis.json
+++ b/openimis.json
@@ -6,7 +6,7 @@
         },
         {
             "name": "individual",
-            "pip": "git+https://github.com/openimis/openimis-be-individual_py.git@develop#egg=openimis-be-individual"
+            "pip": "git+https://github.com/openimis/openimis-be-individual_py.git@fix/group-individual-null-individual-id#egg=openimis-be-individual"
         },
         {
             "name": "workflow",

--- a/openimis.json
+++ b/openimis.json
@@ -38,7 +38,7 @@
         },
         {
             "name": "insuree",
-            "pip": "git+https://github.com/openimis/openimis-be-insuree_py.git@develop#egg=openimis-be-insuree"
+            "pip": "git+https://github.com/openimis/openimis-be-insuree_py.git@chore/flake8-cleanup#egg=openimis-be-insuree"
         },
         {
             "name": "policy",
@@ -62,11 +62,11 @@
         },
         {
             "name": "claim_batch",
-            "pip": "git+https://github.com/openimis/openimis-be-claim_batch_py.git@develop#egg=openimis-be-claim_batch"
+            "pip": "git+https://github.com/openimis/openimis-be-claim_batch_py.git@chore/flake8-cleanup#egg=openimis-be-claim_batch"
         },
         {
             "name": "tools",
-            "pip": "git+https://github.com/openimis/openimis-be-tools_py.git@develop#egg=openimis-be-tools"
+            "pip": "git+https://github.com/openimis/openimis-be-tools_py.git@chore/flake8-cleanup#egg=openimis-be-tools"
         },
         {
             "name": "api_fhir_r4",
@@ -86,7 +86,7 @@
         },
         {
             "name": "contract",
-            "pip": "git+https://github.com/openimis/openimis-be-contract_py.git@develop#egg=openimis-be-contract"
+            "pip": "git+https://github.com/openimis/openimis-be-contract_py.git@fix/subtract-date-ranges-type-mismatch#egg=openimis-be-contract"
         },
         {
             "name": "invoice",
@@ -150,7 +150,7 @@
         },
         {
             "name": "payroll",
-            "pip": "git+https://github.com/openimis/openimis-be-payroll_py.git@develop#egg=openimis-be-payroll"
+            "pip": "git+https://github.com/openimis/openimis-be-payroll_py.git@fix/multiple-project-enrollment#egg=openimis-be-payroll"
         },
         {
             "name": "controls",


### PR DESCRIPTION
## ⚠️ DO NOT MERGE — Close this PR once all 5 module PRs are merged

This PR exists solely to prove that all 5 pending fixes work together and that "Run All Tests" passes with all of them applied. Once that is confirmed, **close this PR without merging** — the `openimis.json` changes here are temporary scaffolding only.

---

## Background

The "Run All Tests" job has been failing on every module PR in `develop` due to 4 independent root-cause bugs. Because each bug causes a DB connection leak that cascades into other modules, no single module PR can get a green "Run All Tests" on its own — they block each other.

This PR pins all 5 modules to their fix branches so CI can verify them together.

## Modules pinned to fix branches

| Module | Fix branch | Fixes | PR |
|--------|-----------|-------|----|
| `insuree` | `chore/flake8-cleanup` | Corrupt PNG in photo test, `mmuid` typo in GQL test | openimis/openimis-be-insuree_py#168 |
| `claim_batch` | `chore/flake8-cleanup` | `health_facility_id` int passed where object expected | openimis/openimis-be-claim_batch_py#75 |
| `tools` | `chore/flake8-cleanup` | Mock user in `test_upload_claims_unknown_hf` | openimis/openimis-be-tools_py#65 |
| `contract` | `fix/subtract-date-ranges-type-mismatch` | `TypeError: can't compare datetime.datetime to AdDate` in `subtract_date_ranges` | openimis/openimis-be-contract_py#113 |
| `payroll` | `fix/multiple-project-enrollment` | `Beneficiary() got unexpected keyword argument 'project'` | openimis/openimis-be-payroll_py#80 |

## Cascade effect

`claim_batch` and `payroll` bugs corrupt the DB connection when `setUpClass` fails, causing every module that runs alphabetically after them to fail with `psycopg2.InterfaceError: connection already closed`. Fixing these two alone clears failures in `tools`, `api_fhir_r4`, `controls`, `grievance_social_protection`, `claim_sampling`, `deduplication`, and `api_etl`.

## Instructions for maintainers

1. Wait for CI on this PR to go green
2. Use the green result as evidence to merge the 5 module PRs listed above into their respective `develop` branches
3. **Close this PR without merging** — once all 5 are merged, `@develop` already points to the fixed code and this `openimis.json` change becomes redundant