### PR TITLE
fix(ci): create 'imis' database before running Django tests

### DIFF
--- a/.github/workflows/ci_assembly.yml
+++ b/.github/workflows/ci_assembly.yml
@@ -102,6 +102,9 @@ jobs:
           git clone  --depth=1 --branch=$DBBRANCH https://github.com/openimis/database_postgresql.git ./sql_psql
           sudo bash ./sql_psql/install_postgres_json_schema_extension.sh
           echo 'set search_path to public' >> ~/.psqlrc
+          # The pgsql service container creates test_imis (POSTGRES_DB=test_imis) but not imis.
+          # Django requires the main DB (imis) to exist at startup, even with --keepdb.
+          PGPASSWORD=$DB_PASSWORD psql -U $DB_USER -h $DB_HOST -d postgres -c "CREATE DATABASE $DB_NAME;" || true
           PGPASSWORD=YourStrong!Passw0rd psql -U $DB_USER -h $DB_HOST -d $DB_NAME_TEST -f  ./sql_psql/database\ scripts/json_schema_extension.sql | grep . | uniq -c
         env:
           DB_HOST: localhost


### PR DESCRIPTION
## Problem

Every CI run on `ci_assembly.yml` fails immediately with:

```
psycopg2.OperationalError: FATAL:  database "imis" does not exist
```

This happens before any test executes, causing the entire test suite to report as `FailedTest` (import-time error).

## Root cause

The pgsql service container is configured with `POSTGRES_DB: test_imis`, so PostgreSQL starts with only `test_imis` (and the built-in `postgres`) databases. The Django test step uses `DB_NAME: imis` — but `imis` never exists. Django's test runner tries to connect to `imis` at startup (even with `--keepdb`) to validate the connection before switching to the test database.

## Fix

Add a `CREATE DATABASE imis` call in the **Initialize PSQL** step, using the always-present `postgres` template database as the connection target. The `|| true` guard makes it idempotent (safe if `imis` already exists).

```bash
PGPASSWORD=$DB_PASSWORD psql -U $DB_USER -h $DB_HOST -d postgres -c "CREATE DATABASE $DB_NAME;" || true
```

## Impact

This has been broken since at least 2026-04-08 (verified against historical CI runs). Every PR's "Run All Tests" job has been reporting infrastructure failures unrelated to the code under review.

## Test plan

- [ ] Verify the `ci_assembly` job passes the "Initialize PSQL" step without error
- [ ] Verify Django tests proceed past the connection phase and actually run