### PR TITLE
feat: register ClaimGuard backend module in openimis.json

### DIFF
--- a/CLAIMGUARD.md
+++ b/CLAIMGUARD.md
@@ -1,0 +1,23 @@
+# ClaimGuard — Backend Assembly Notes
+
+This fork registers the **ClaimGuard** fraud detection module in `openimis.json` for the Technikali openIMIS Hackathon submission.
+
+**Tag:** `v1.0-hackathon`  
+**PR:** [openimis/openimis-be_py#385](https://github.com/openimis/openimis-be_py/pull/385)
+
+## Change in this fork
+
+```json
+{
+  "name": "claimguard",
+  "pip": "-e /openimis-be/openimis-be-claimguard_py"
+}
+```
+
+The `-e` path is for Docker volume-mount development. See the full module at:
+
+**https://github.com/Nosh-thee-techy/openimis-be-claimguard_py**
+
+## Full stack setup
+
+See **https://github.com/Nosh-thee-techy/openimis-dist_dkr** for Docker Compose instructions.

--- a/openimis.json
+++ b/openimis.json
@@ -171,6 +171,10 @@
         {
             "name": "api_etl",
             "pip": "git+https://github.com/openimis/openimis-be-api_etl_py.git@develop#egg=openimis-be-api_etl"
+        },
+        {
+            "name": "claimguard",
+            "pip": "-e /openimis-be/openimis-be-claimguard_py"
         }
     ]
 }


### PR DESCRIPTION
## Description

Registers the **ClaimGuard** backend module in the assembly `openimis.json` for the openIMIS Hackathon (Track 3 — Claims Management & Fraud Detection).

ClaimGuard is an explainable AI fraud overlay that scores claims (0–100) using rule-based checks plus an Isolation Forest model. It hooks into openIMIS via Django `post_save` signals without modifying core claim workflows.

**This PR only adds module registration.** The full implementation lives in a separate module repository (linked below).

### Cross-track integrations
- **Track 3** — Claims processing rails, facility baselines, reviewer queue
- **Track 5** — Isolation Forest XAI engine, plain-language risk vectors
- **Track 1** — Native openIMIS module overlay (no monkey-patching)

## Related repositories (submission tag: `v1.0-hackathon`)

| Repo | Purpose |
|------|---------|
| https://github.com/Nosh-thee-techy/openimis-be-claimguard_py | Backend module (scoring, GraphQL, REST API) |
| https://github.com/Nosh-thee-techy/openimis-fe-claimguard_js | Frontend module (dashboard, XAI panel, override workflow) |
| https://github.com/Nosh-thee-techy/openimis-dist_dkr | Docker compose wiring + setup docs |
| https://github.com/Nosh-thee-techy/openimis-fe_js | Frontend assembly (separate PR) |

## What changed in this PR

- Added `claimguard` entry to `openimis.json`:
  ```json
  { "name": "claimguard", "pip": "-e /openimis-be/openimis-be-claimguard_py" }