### PR TITLE
chore: bump PyJWT to 2.9 for PyJWKClient JWKS caching

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -19,7 +19,7 @@ mssql-django~=1.4
 django-test-without-migrations
 graphene-django<3
 graphene-django-optimizer==0.8.0
-PyJWT~=2.4.0
+PyJWT~=2.9.0
 django-graphql-jwt==0.3.4
 markdown~=3.4.1
 nepalicalendar


### PR DESCRIPTION
`PyJWT~=2.4.0` → `PyJWT~=2.9.0`.

`PyJWKClient` gained the arguments needed to cache a JWKS — `cache_keys`, `lifespan` — plus `timeout` in 2.6. On 2.4 there is no way to cache signing keys, so any OIDC token validation has to fetch the provider's JWKS on the request path. This unblocks that work; nothing in the current code changes behaviour.

### Compatibility

- Across the 53 installed modules, only `core/jwt.py` and `core/jwt_authentication.py` import `jwt` directly, so the surface is small.
- `django-graphql-jwt==0.3.4` requires `PyJWT>=2,<3` — 2.9 satisfies it.

### Verification, on 2.9

- `manage.py test core` — **204 tests, OK**
- `manage.py test opensearch_reports` — **10 tests, OK** (covers the JWT-cookie authentication path)
