### PR TITLE
chore: add factory_boy for test factories - OP-3114

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -61,6 +61,7 @@ password-validator==1.0
 django-axes==6.4.0
 django-split-settings
 faker
+factory_boy
 django-csp
 sqlparse>=0.5.0 # not directly required, pinned by Snyk to avoid a vulnerability
 debugpy


### PR DESCRIPTION
Adds `factory_boy` next to `faker`, which is already there and used by the same kind of code.

This is the enabling change for OP-3114: seven backend packages get a `test_factories.py` sitting under their existing `create_test_*` helpers, so that test data can be composed from any point in an object graph without changing a single call site. Declared here rather than in each package's `setup.py`, matching how `faker` and `coverage` are handled — no package declares a test library in `install_requires`, including `claim`, whose shipped `generateclaimadmins` command imports Faker.

`factory_boy` 3.3.3 installs on Python 3.11 and pulls in `faker`, which is already a dependency, so this adds no new transitive surface.

Opening this one first on purpose. The package changes are prepared on branches (`core`, `location`, `product`, `medical`, `insuree`, `policy`, `claim`) but not submitted yet, because without this line their CI fails on `ModuleNotFoundError: No module named 'factory'`. They are independent of each other and will follow once this lands, or can be reviewed alongside it on request.

Nothing else in the repository changes, and nothing imports `factory` yet, so this is inert on its own.
