### PR TITLE
OP-3125 fix(ci): resolve editable-installed module source in settings

### DIFF
--- a/.github/workflows/ci_assembly.yml
+++ b/.github/workflows/ci_assembly.yml
@@ -148,6 +148,13 @@ jobs:
       #     DB_USER: sa
       #     DB_PASSWORD: YourStrong!Passw0rd
 
+      - name: Settings unit tests
+        working-directory: ./openIMIS
+        # Pure-stdlib unit tests for settings helpers; not collected by
+        # `manage.py test <module>`, so run them explicitly.
+        if: success() || failure()
+        run: python openIMIS/settings/test_base_utils.py
+
       - name: Django tests PSQL
         working-directory: ./openIMIS
         # Run the tests regardless if previous steps failed (if setup fails the tests should crash instantly)

--- a/openIMIS/openIMIS/settings/base.py
+++ b/openIMIS/openIMIS/settings/base.py
@@ -6,10 +6,10 @@ import json
 import logging
 import os
 import sys
-from pathlib import Path
 
 from ..openimisapps import openimis_apps, get_locale_folders
 from datetime import timedelta
+from .base_utils import locate_module_file
 from .common import DEBUG, BASE_DIR, MODE
 from .security import REMOTE_USER_AUTHENTICATION
 
@@ -72,20 +72,6 @@ INSTALLED_APPS += ["apscheduler_runner", "signal_binding", "receiver_binding"]  
 IS_TESTING =  'test' in sys.argv
 
 
-def _locate_module_file(module_dotted_path):
-    """Find a module file on sys.path without importing it."""
-    relative = Path(*module_dotted_path.split("."))
-    for entry in sys.path:
-        base = Path(entry)
-        for candidate in (
-            base / relative.with_suffix(".py"),
-            base / relative / "__init__.py",
-        ):
-            if candidate.is_file():
-                return candidate
-    return None
-
-
 _CORE_EXTENSIONS = {
     "graphql_jwt_backend": (
         "core.jwt_authentication.JSONWebTokenBackend",
@@ -130,7 +116,7 @@ def _core_module_classes(extensions):
     }
     classes_by_module = {}
     for module_path in module_paths:
-        module_file = _locate_module_file(module_path)
+        module_file = locate_module_file(module_path)
         if module_file is None:
             classes_by_module[module_path] = set()
             continue

--- a/openIMIS/openIMIS/settings/base_utils.py
+++ b/openIMIS/openIMIS/settings/base_utils.py
@@ -1,0 +1,35 @@
+"""Small, Django-independent helpers for the settings package, kept out of
+base.py so they can be unit-tested in isolation (see test_base_utils.py)."""
+
+import importlib.util
+import sys
+from pathlib import Path
+
+
+def locate_module_file(module_dotted_path):
+    """Find a module's source file without importing it.
+
+    Scans ``sys.path``, and also resolves the top-level package through the
+    import system, so editable installs exposed via an import finder (PEP 660) —
+    whose package directory is not on ``sys.path`` — are still found.
+    ``find_spec`` on the top-level package does not execute its ``__init__.py``.
+    """
+    parts = module_dotted_path.split(".")
+    relative = Path(*parts)
+
+    bases = [Path(entry) for entry in sys.path]
+    try:
+        top_spec = importlib.util.find_spec(parts[0])
+    except (ImportError, ValueError):
+        top_spec = None
+    if top_spec and top_spec.submodule_search_locations:
+        bases.extend(Path(loc).parent for loc in top_spec.submodule_search_locations)
+
+    for base in bases:
+        for candidate in (
+            base / relative.with_suffix(".py"),
+            base / relative / "__init__.py",
+        ):
+            if candidate.is_file():
+                return candidate
+    return None

--- a/openIMIS/openIMIS/settings/test_base_utils.py
+++ b/openIMIS/openIMIS/settings/test_base_utils.py
@@ -1,0 +1,73 @@
+"""Regression test for locate_module_file (OP-3125).
+
+Loads base_utils directly from its file so the test stays hermetic — no Django
+settings / celery import chain.
+"""
+
+import importlib.abc
+import importlib.util
+import sys
+import unittest
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+_MODULE_PATH = Path(__file__).with_name("base_utils.py")
+_spec = importlib.util.spec_from_file_location("_base_utils_under_test", _MODULE_PATH)
+_base_utils = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(_base_utils)
+locate_module_file = _base_utils.locate_module_file
+
+
+class _FinderOnly(importlib.abc.MetaPathFinder):
+    """Expose a package through find_spec only — like a PEP 660 editable install
+    — without putting its directory on sys.path."""
+
+    def __init__(self, name, pkg_dir):
+        self._name = name
+        self._spec = importlib.util.spec_from_file_location(
+            name,
+            pkg_dir / "__init__.py",
+            submodule_search_locations=[str(pkg_dir)],
+        )
+
+    def find_spec(self, fullname, path=None, target=None):
+        return self._spec if fullname == self._name else None
+
+
+def _make_pkg(root, name, submodule):
+    pkg = Path(root) / name
+    pkg.mkdir()
+    (pkg / "__init__.py").write_text("")
+    (pkg / f"{submodule}.py").write_text("class A:\n    pass\n")
+    return pkg
+
+
+class LocateModuleFileTests(unittest.TestCase):
+    def test_finds_module_on_sys_path(self):
+        with TemporaryDirectory() as tmp:
+            pkg = _make_pkg(tmp, "pathpkg", "sub")
+            sys.path.insert(0, tmp)
+            try:
+                found = locate_module_file("pathpkg.sub")
+            finally:
+                sys.path.remove(tmp)
+            self.assertEqual(found, pkg / "sub.py")
+
+    def test_finds_finder_based_module_not_on_sys_path(self):
+        # Regression (OP-3125): editable installs (PEP 660) expose the package
+        # through an import finder, not a sys.path entry, so a sys.path-only
+        # scan misses the source.
+        with TemporaryDirectory() as tmp:
+            pkg = _make_pkg(tmp, "finderpkg", "mod")
+            self.assertNotIn(tmp, sys.path)
+            finder = _FinderOnly("finderpkg", pkg)
+            sys.meta_path.insert(0, finder)
+            try:
+                found = locate_module_file("finderpkg.mod")
+            finally:
+                sys.meta_path.remove(finder)
+            self.assertEqual(found, pkg / "mod.py")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
# Description

The settings resolver `_locate_module_file` finds a module's source by scanning
**`sys.path`** only. When a module (e.g. `core`) is installed as a **PEP 660**
editable / finder-based install — whose package directory is not on `sys.path` —
the scan returns `None`, so `_resolve_core_extensions` drops every class in
`core.middleware` / `core.security` / `core.jwt_authentication`, including
**`DefaultAxesAttributesMiddleware`** (which sets `request.axes_ip_address`).
Token-auth's lockout check then crashes with
`'WSGIRequest' object has no attribute 'axes_ip_address'`, failing the login
GraphQL tests and breaking CI for every module repo (the `-e ../../current-module`
install), and for `develop` itself.

**Fix:** locate the source via `importlib.util.find_spec` on the **top-level**
package (which does not execute its `__init__.py`) and use its
`submodule_search_locations`, so finder-based editable installs are found. The
function is moved (as `locate_module_file`) into `settings/base_utils.py` so it
is unit-testable in isolation (`test_base_utils.py`); `_core_module_classes` and
`_resolve_core_extensions` stay in `base.py` (only the call site changed).

# Type of Change

- [ ] Feature
- [x] Bug fix
- [ ] Chore (Refactor, Docs, CI/CD)
- [ ] Other, please specify

## Related Issue(s) / Task(s)
- OP-3125
- Repro — `develop` "Run Module Tests" re-run showing `core is missing default_axes_attributes … skipping` + the axes login failures: https://github.com/openimis/openimis-be-core_py/actions/runs/33661775148

## Notes
Environmental regression, surfaced when the CI image's setuptools/pip began
producing PEP 660 editable installs — not caused by any module change.

## Checklist
- [x] Unit tests added/modified
- [ ] I18n / translation handled