### PR TITLE
OP-3133: Install the django-otp device apps

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -88,3 +88,21 @@ OPEN_SEARCH_HTTP_PORT=9200
 # then has to be strong: the demo installer rejects an empty one.
 OPENSEARCH_SECURITY_DISABLED=true
 OPENSEARCH_DISABLE_DEMO_CONFIG=true
+
+# Token signing. Provisioning a key is the switch to deployment-key signing;
+# there is no mode setting. Accepts a path to a mounted PEM or an inline PEM.
+# Unset means the legacy per-user signing key. Generate with:
+#   openssl genrsa -out jwt_signing_key.pem 2048
+#JWT_SIGNING_KEY=/var/openimis/keys/jwt_signing_key.pem
+
+# Token issuer and audience. WARNING: setting JWT_ISSUER invalidates every token
+# already in circulation, because tokens issued before it was set carry no "iss"
+# claim - every user is logged out once and must sign in again. Tokens expire
+# after a day, so set it during a maintenance window. Clearing it rolls back.
+#JWT_ISSUER=https://openimis.example.org
+#JWT_AUDIENCE=openimis
+
+# Rotation: to keep a retiring key verifiable, put its public half in the
+# JWT_DEPLOYMENT_KEYS setting ({kid: key}, settings only - not an environment
+# variable) BEFORE changing JWT_SIGNING_KEY, or every token it signed stops
+# verifying at once.

--- a/.env.example
+++ b/.env.example
@@ -95,14 +95,15 @@ OPENSEARCH_DISABLE_DEMO_CONFIG=true
 #   openssl genrsa -out jwt_signing_key.pem 2048
 #JWT_SIGNING_KEY=/var/openimis/keys/jwt_signing_key.pem
 
-# Token issuer and audience. WARNING: setting JWT_ISSUER invalidates every token
+# Token issuer and audience. WARNING: setting either one invalidates every token
 # already in circulation, because tokens issued before it was set carry no "iss"
-# claim - every user is logged out once and must sign in again. Tokens expire
-# after a day, so set it during a maintenance window. Clearing it rolls back.
+# or "aud" claim - every user is logged out once and must sign in again. Tokens
+# expire after a day, so set them during a maintenance window. Clearing them
+# rolls back.
 #JWT_ISSUER=https://openimis.example.org
 #JWT_AUDIENCE=openimis
 
-# Rotation: to keep a retiring key verifiable, put its public half in the
-# JWT_DEPLOYMENT_KEYS setting ({kid: key}, settings only - not an environment
-# variable) BEFORE changing JWT_SIGNING_KEY, or every token it signed stops
-# verifying at once.
+# Rotation: to keep a retiring key verifiable, its public half must be in the
+# JWT_DEPLOYMENT_KEYS setting ({kid: public key}) BEFORE JWT_SIGNING_KEY changes,
+# or every token it signed stops verifying at once. That setting has no
+# environment variable yet and needs a Django settings override to reach it.

--- a/README.md
+++ b/README.md
@@ -448,23 +448,32 @@ module skeleton in single command` section
 
 ### JWT Security Configuration
 
-To enhance JWT token security, you can configure the system to use RSA keys for signing and verifying tokens.
+openIMIS signs tokens with a deployment RSA keypair when one is provisioned, and with the legacy
+per-user key when none is. Provisioning the key is the switch; there is no mode setting.
 
-1. **Generate RSA Keys**:
+1. **Generate a signing key**:
+
  ```bash
- # Generate a private key
- openssl genpkey -algorithm RSA -out jwt_private_key.pem -aes256
+ openssl genrsa -out jwt_signing_key.pem 2048
+ ```
 
- # Generate a public key
- openssl rsa -pubout -in jwt_private_key.pem -out jwt_public_key.pem
+ Do not passphrase-protect it: the loader opens the key with no password and rejects one that needs
+ a passphrase.
 
-2. **Store RSA Keys**:
- Place jwt_private_key.pem and jwt_public_key.pem in a secure directory within your project, e.g., keys/.
+2. **Point the backend at it** with `JWT_SIGNING_KEY`, which takes either a path to a mounted PEM or
+ the PEM itself inline:
 
-3. **Django Configuration**:
- Ensure that the settings.py file is configured to read these keys. If RSA keys are found, the system will use RS256. Otherwise, it will fallback to HS256 using DJANGO_SECRET_KEY.
+ ```
+ JWT_SIGNING_KEY=/var/openimis/keys/jwt_signing_key.pem
+ ```
 
-Note: If RSA keys are not provided, the system defaults to HS256. Using RS256 with RSA keys is recommended for enhanced security.
+ Tokens are then signed RS256 and carry a `kid` derived from the key itself, so replicas agree on
+ it without sharing anything. Leave the setting unset to keep the legacy per-user key.
+
+3. **Optionally set `JWT_ISSUER` and `JWT_AUDIENCE`**. Both default to unset. **Setting either one
+ invalidates every token already in circulation**, so do it during a maintenance window.
+
+See `.env.example` for all three settings and for the key rotation procedure.
 
 ## CSRF Setup Guide
 

--- a/openIMIS/openIMIS/settings/__init__.py
+++ b/openIMIS/openIMIS/settings/__init__.py
@@ -6,8 +6,6 @@ import logging
 import os
 
 from ..openimisapps import openimis_apps, get_locale_folders
-from datetime import timedelta
-from cryptography.hazmat.primitives import serialization
 from .common import MODE
 
 from split_settings.tools import optional, include

--- a/openIMIS/openIMIS/settings/security.py
+++ b/openIMIS/openIMIS/settings/security.py
@@ -42,7 +42,7 @@ GRAPHQL_JWT = {
     "JWT_ISSUER": os.environ.get("JWT_ISSUER") or None,
     "JWT_AUDIENCE": os.environ.get("JWT_AUDIENCE") or None,
     "JWT_ENCODE_HANDLER": "core.jwt.jwt_encode_user_key",
-    "JWT_DECODE_HANDLER": "core.jwt.jwt_decode_user_key",
+    "JWT_DECODE_HANDLER": "core.auth.decode",
     # This can be used to expose some resources without authentication
     "JWT_ALLOW_ANY_CLASSES": [
         "graphql_jwt.mutations.ObtainJSONWebToken",

--- a/openIMIS/openIMIS/settings/security.py
+++ b/openIMIS/openIMIS/settings/security.py
@@ -53,6 +53,10 @@ GRAPHQL_JWT = {
     ],
 }
 
+# Provisioning this key is the switch to deployment-key signing; there is no mode setting.
+JWT_SIGNING_KEY = os.environ.get("JWT_SIGNING_KEY") or None
+
+
 # Lockout mechanism configuration
 AXES_FAILURE_LIMIT = int(os.getenv("LOGIN_LOCKOUT_FAILURE_LIMIT", 5))
 AXES_COOLOFF_TIME = timedelta(minutes=int(os.getenv("LOGIN_LOCKOUT_COOLOFF_TIME", 5)))

--- a/openIMIS/openIMIS/settings/security.py
+++ b/openIMIS/openIMIS/settings/security.py
@@ -38,6 +38,9 @@ GRAPHQL_JWT = {
     "JWT_EXPIRATION_DELTA": timedelta(days=1),
     "JWT_REFRESH_EXPIRATION_DELTA": timedelta(days=30),
     "JWT_AUTH_HEADER_PREFIX": "Bearer",
+    # Setting JWT_ISSUER invalidates every token already in circulation; see .env.example.
+    "JWT_ISSUER": os.environ.get("JWT_ISSUER") or None,
+    "JWT_AUDIENCE": os.environ.get("JWT_AUDIENCE") or None,
     "JWT_ENCODE_HANDLER": "core.jwt.jwt_encode_user_key",
     "JWT_DECODE_HANDLER": "core.jwt.jwt_decode_user_key",
     # This can be used to expose some resources without authentication

--- a/openIMIS/openIMIS/settings/security.py
+++ b/openIMIS/openIMIS/settings/security.py
@@ -38,7 +38,7 @@ GRAPHQL_JWT = {
     "JWT_EXPIRATION_DELTA": timedelta(days=1),
     "JWT_REFRESH_EXPIRATION_DELTA": timedelta(days=30),
     "JWT_AUTH_HEADER_PREFIX": "Bearer",
-    # Setting JWT_ISSUER invalidates every token already in circulation; see .env.example.
+    # Setting either of these invalidates every token already in circulation; see .env.example.
     "JWT_ISSUER": os.environ.get("JWT_ISSUER") or None,
     "JWT_AUDIENCE": os.environ.get("JWT_AUDIENCE") or None,
     "JWT_ENCODE_HANDLER": "core.jwt.jwt_encode_user_key",

--- a/openIMIS/openIMIS/settings/security.py
+++ b/openIMIS/openIMIS/settings/security.py
@@ -1,7 +1,6 @@
 import os
-from .common import DEBUG, BASE_DIR
+from .common import DEBUG
 from datetime import timedelta
-from cryptography.hazmat.primitives import serialization
 
 
 AUTH_USER_MODEL = "core.User"
@@ -53,30 +52,6 @@ GRAPHQL_JWT = {
         "core.schema.SetPasswordMutation",
     ],
 }
-
-# Load RSA keys
-private_key_path = os.path.join(BASE_DIR, 'keys', 'jwt_private_key.pem')
-public_key_path = os.path.join(BASE_DIR, 'keys', 'jwt_public_key.pem')
-
-if os.path.exists(private_key_path) and os.path.exists(public_key_path):
-    with open(private_key_path, 'rb') as f:
-        private_key = serialization.load_pem_private_key(
-            f.read(),
-            password=None,
-        )
-
-    with open(public_key_path, 'rb') as f:
-        public_key = serialization.load_pem_public_key(
-            f.read(),
-        )
-
-    # If RSA keys exist, update the algorithm and add keys to GRAPHQL_JWT settings
-    GRAPHQL_JWT.update({
-        "JWT_ALGORITHM": "RS256",
-        "JWT_PRIVATE_KEY": private_key,
-        "JWT_PUBLIC_KEY": public_key,
-    })
-
 
 # Lockout mechanism configuration
 AXES_FAILURE_LIMIT = int(os.getenv("LOGIN_LOCKOUT_FAILURE_LIMIT", 5))


### PR DESCRIPTION
> **Stacked on #392 — do not review until that merges.** Cut from
> `feat/assembly-signing-settings`, so GitHub shows 9 commits and 5 files; 2 commits and 2 files are
> this change (`0ca6269`, `6fb7e59`). **Also needs
> [openimis-be-core_py#460](https://github.com/openimis/openimis-be-core_py/pull/460)**, which adds
> the `django-otp` dependency and the code that uses these models. Merge that first.

## Why

`OPENIMIS_APPS` is derived solely from `openimis.json` (`openIMIS/openimisapps.py`), so a module
cannot contribute a third-party Django app. `core`'s second-factor layer needs `django-otp`'s device
tables, so the apps go in the assembly's static list — the same way `axes` and
`django_opensearch_dsl` already do.

## What changes

`django_otp` and its `otp_totp` / `otp_static` plugins in `INSTALLED_APPS`, with `otp_totp` first so
an authenticator code is tried before a recovery code. `django_otp` itself declares no concrete
model and creates no table; only the two plugins migrate.

Two settings in `security.py`:

- `OTP_TOTP_ISSUER`, environment-driven, defaulting to `openIMIS` — the label an authenticator app
  shows beside the account.
- `OTP_ADMIN_HIDE_SENSITIVE_DATA = True`. The plugins register on the admin site unconditionally, and
  django-otp defaults this to `False`, which puts the TOTP shared key and a QR link on every device's
  admin page. A superuser could then clone another user's authenticator — quieter than the password
  reset they can already perform, since a victim notices a reset but not a copied seed. The list
  view stays usable for spotting and deleting a lost device.

## What does not change

- **No Python code**, no dependency added here — `django-otp` is declared by `core`.
- **Six migrations** arrive with the plugin apps and are applied by `migrate`; the assembly declares
  none of its own.
- **No behaviour for existing users.** Nothing calls the second-factor layer until OP-3134.

## CI will be red until #460 merges — expected

`ci_assembly` fails at *Django tests PSQL* with:

```
ModuleNotFoundError: No module named 'django_otp'
  ... django.setup() -> apps.populate(settings.INSTALLED_APPS)
```

CI installs `openimis-be-core` from `openimis/openimis-be-core_py.git@develop` (the `openimis.json`
pin, via `modules-requirements.txt`), and `develop` does not yet declare `django-otp` — that
declaration is in #460. So Django cannot import the app this PR adds to `INSTALLED_APPS`.

This resolves itself when #460 merges and the pin picks the dependency up transitively. **It is
deliberately not worked around** by also declaring `django-otp` in the assembly: the module that
uses a library owns its dependency, and duplicating it here would make this PR go green on a
declaration that belongs elsewhere.

`SonarCloud` also fails, for an unrelated and pre-existing reason: fork PRs get no repository
secrets, so the scanner exits in ~10s with `Not authorized... check the 'SONAR_TOKEN'`. The parent
#392 fails it identically.

## Tests

The assembly has no unit suite for settings. Verified on a running stack: `manage.py check` clean;
`migrate` applied `otp_static` and `otp_totp` 0001–0003; both device tables FK `user_id` to
`core_User` as `uuid`; `tokenAuth` still issues an RS256 token with a `kid`; a browser login reaches
`/front/home` with no console errors. `core` suite **413 passing** against this assembly.

`OTP_ADMIN_HIDE_SENSITIVE_DATA` checked by fetching a real device's admin change page with an
authenticated session: `name="key"` and the qrcode link absent, `name` and `confirmed` present.

Ticket: OP-3133