### PR TITLE
OP-3131: Backend assembly signing key, issuer and audience settings

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -88,3 +88,21 @@ OPEN_SEARCH_HTTP_PORT=9200
 # then has to be strong: the demo installer rejects an empty one.
 OPENSEARCH_SECURITY_DISABLED=true
 OPENSEARCH_DISABLE_DEMO_CONFIG=true
+
+# Token signing. Provisioning a key is the switch to deployment-key signing;
+# there is no mode setting. Accepts a path to a mounted PEM or an inline PEM.
+# Unset means the legacy per-user signing key. Generate with:
+#   openssl genrsa -out jwt_signing_key.pem 2048
+#JWT_SIGNING_KEY=/var/openimis/keys/jwt_signing_key.pem
+
+# Token issuer and audience. WARNING: setting JWT_ISSUER invalidates every token
+# already in circulation, because tokens issued before it was set carry no "iss"
+# claim - every user is logged out once and must sign in again. Tokens expire
+# after a day, so set it during a maintenance window. Clearing it rolls back.
+#JWT_ISSUER=https://openimis.example.org
+#JWT_AUDIENCE=openimis
+
+# Rotation: to keep a retiring key verifiable, put its public half in the
+# JWT_DEPLOYMENT_KEYS setting ({kid: key}, settings only - not an environment
+# variable) BEFORE changing JWT_SIGNING_KEY, or every token it signed stops
+# verifying at once.

--- a/.env.example
+++ b/.env.example
@@ -95,14 +95,15 @@ OPENSEARCH_DISABLE_DEMO_CONFIG=true
 #   openssl genrsa -out jwt_signing_key.pem 2048
 #JWT_SIGNING_KEY=/var/openimis/keys/jwt_signing_key.pem
 
-# Token issuer and audience. WARNING: setting JWT_ISSUER invalidates every token
+# Token issuer and audience. WARNING: setting either one invalidates every token
 # already in circulation, because tokens issued before it was set carry no "iss"
-# claim - every user is logged out once and must sign in again. Tokens expire
-# after a day, so set it during a maintenance window. Clearing it rolls back.
+# or "aud" claim - every user is logged out once and must sign in again. Tokens
+# expire after a day, so set them during a maintenance window. Clearing them
+# rolls back.
 #JWT_ISSUER=https://openimis.example.org
 #JWT_AUDIENCE=openimis
 
-# Rotation: to keep a retiring key verifiable, put its public half in the
-# JWT_DEPLOYMENT_KEYS setting ({kid: key}, settings only - not an environment
-# variable) BEFORE changing JWT_SIGNING_KEY, or every token it signed stops
-# verifying at once.
+# Rotation: to keep a retiring key verifiable, its public half must be in the
+# JWT_DEPLOYMENT_KEYS setting ({kid: public key}) BEFORE JWT_SIGNING_KEY changes,
+# or every token it signed stops verifying at once. That setting has no
+# environment variable yet and needs a Django settings override to reach it.

--- a/README.md
+++ b/README.md
@@ -448,23 +448,32 @@ module skeleton in single command` section
 
 ### JWT Security Configuration
 
-To enhance JWT token security, you can configure the system to use RSA keys for signing and verifying tokens.
+openIMIS signs tokens with a deployment RSA keypair when one is provisioned, and with the legacy
+per-user key when none is. Provisioning the key is the switch; there is no mode setting.
 
-1. **Generate RSA Keys**:
+1. **Generate a signing key**:
+
  ```bash
- # Generate a private key
- openssl genpkey -algorithm RSA -out jwt_private_key.pem -aes256
+ openssl genrsa -out jwt_signing_key.pem 2048
+ ```
 
- # Generate a public key
- openssl rsa -pubout -in jwt_private_key.pem -out jwt_public_key.pem
+ Do not passphrase-protect it: the loader opens the key with no password and rejects one that needs
+ a passphrase.
 
-2. **Store RSA Keys**:
- Place jwt_private_key.pem and jwt_public_key.pem in a secure directory within your project, e.g., keys/.
+2. **Point the backend at it** with `JWT_SIGNING_KEY`, which takes either a path to a mounted PEM or
+ the PEM itself inline:
 
-3. **Django Configuration**:
- Ensure that the settings.py file is configured to read these keys. If RSA keys are found, the system will use RS256. Otherwise, it will fallback to HS256 using DJANGO_SECRET_KEY.
+ ```
+ JWT_SIGNING_KEY=/var/openimis/keys/jwt_signing_key.pem
+ ```
 
-Note: If RSA keys are not provided, the system defaults to HS256. Using RS256 with RSA keys is recommended for enhanced security.
+ Tokens are then signed RS256 and carry a `kid` derived from the key itself, so replicas agree on
+ it without sharing anything. Leave the setting unset to keep the legacy per-user key.
+
+3. **Optionally set `JWT_ISSUER` and `JWT_AUDIENCE`**. Both default to unset. **Setting either one
+ invalidates every token already in circulation**, so do it during a maintenance window.
+
+See `.env.example` for all three settings and for the key rotation procedure.
 
 ## CSRF Setup Guide
 

--- a/openIMIS/openIMIS/settings/__init__.py
+++ b/openIMIS/openIMIS/settings/__init__.py
@@ -6,8 +6,6 @@ import logging
 import os
 
 from ..openimisapps import openimis_apps, get_locale_folders
-from datetime import timedelta
-from cryptography.hazmat.primitives import serialization
 from .common import MODE
 
 from split_settings.tools import optional, include

--- a/openIMIS/openIMIS/settings/security.py
+++ b/openIMIS/openIMIS/settings/security.py
@@ -42,7 +42,7 @@ GRAPHQL_JWT = {
     "JWT_ISSUER": os.environ.get("JWT_ISSUER") or None,
     "JWT_AUDIENCE": os.environ.get("JWT_AUDIENCE") or None,
     "JWT_ENCODE_HANDLER": "core.jwt.jwt_encode_user_key",
-    "JWT_DECODE_HANDLER": "core.jwt.jwt_decode_user_key",
+    "JWT_DECODE_HANDLER": "core.auth.decode",
     # This can be used to expose some resources without authentication
     "JWT_ALLOW_ANY_CLASSES": [
         "graphql_jwt.mutations.ObtainJSONWebToken",

--- a/openIMIS/openIMIS/settings/security.py
+++ b/openIMIS/openIMIS/settings/security.py
@@ -53,6 +53,10 @@ GRAPHQL_JWT = {
     ],
 }
 
+# Provisioning this key is the switch to deployment-key signing; there is no mode setting.
+JWT_SIGNING_KEY = os.environ.get("JWT_SIGNING_KEY") or None
+
+
 # Lockout mechanism configuration
 AXES_FAILURE_LIMIT = int(os.getenv("LOGIN_LOCKOUT_FAILURE_LIMIT", 5))
 AXES_COOLOFF_TIME = timedelta(minutes=int(os.getenv("LOGIN_LOCKOUT_COOLOFF_TIME", 5)))

--- a/openIMIS/openIMIS/settings/security.py
+++ b/openIMIS/openIMIS/settings/security.py
@@ -38,6 +38,9 @@ GRAPHQL_JWT = {
     "JWT_EXPIRATION_DELTA": timedelta(days=1),
     "JWT_REFRESH_EXPIRATION_DELTA": timedelta(days=30),
     "JWT_AUTH_HEADER_PREFIX": "Bearer",
+    # Setting JWT_ISSUER invalidates every token already in circulation; see .env.example.
+    "JWT_ISSUER": os.environ.get("JWT_ISSUER") or None,
+    "JWT_AUDIENCE": os.environ.get("JWT_AUDIENCE") or None,
     "JWT_ENCODE_HANDLER": "core.jwt.jwt_encode_user_key",
     "JWT_DECODE_HANDLER": "core.jwt.jwt_decode_user_key",
     # This can be used to expose some resources without authentication

--- a/openIMIS/openIMIS/settings/security.py
+++ b/openIMIS/openIMIS/settings/security.py
@@ -38,7 +38,7 @@ GRAPHQL_JWT = {
     "JWT_EXPIRATION_DELTA": timedelta(days=1),
     "JWT_REFRESH_EXPIRATION_DELTA": timedelta(days=30),
     "JWT_AUTH_HEADER_PREFIX": "Bearer",
-    # Setting JWT_ISSUER invalidates every token already in circulation; see .env.example.
+    # Setting either of these invalidates every token already in circulation; see .env.example.
     "JWT_ISSUER": os.environ.get("JWT_ISSUER") or None,
     "JWT_AUDIENCE": os.environ.get("JWT_AUDIENCE") or None,
     "JWT_ENCODE_HANDLER": "core.jwt.jwt_encode_user_key",

--- a/openIMIS/openIMIS/settings/security.py
+++ b/openIMIS/openIMIS/settings/security.py
@@ -1,7 +1,6 @@
 import os
-from .common import DEBUG, BASE_DIR
+from .common import DEBUG
 from datetime import timedelta
-from cryptography.hazmat.primitives import serialization
 
 
 AUTH_USER_MODEL = "core.User"
@@ -53,30 +52,6 @@ GRAPHQL_JWT = {
         "core.schema.SetPasswordMutation",
     ],
 }
-
-# Load RSA keys
-private_key_path = os.path.join(BASE_DIR, 'keys', 'jwt_private_key.pem')
-public_key_path = os.path.join(BASE_DIR, 'keys', 'jwt_public_key.pem')
-
-if os.path.exists(private_key_path) and os.path.exists(public_key_path):
-    with open(private_key_path, 'rb') as f:
-        private_key = serialization.load_pem_private_key(
-            f.read(),
-            password=None,
-        )
-
-    with open(public_key_path, 'rb') as f:
-        public_key = serialization.load_pem_public_key(
-            f.read(),
-        )
-
-    # If RSA keys exist, update the algorithm and add keys to GRAPHQL_JWT settings
-    GRAPHQL_JWT.update({
-        "JWT_ALGORITHM": "RS256",
-        "JWT_PRIVATE_KEY": private_key,
-        "JWT_PUBLIC_KEY": public_key,
-    })
-
 
 # Lockout mechanism configuration
 AXES_FAILURE_LIMIT = int(os.getenv("LOGIN_LOCKOUT_FAILURE_LIMIT", 5))


### PR DESCRIPTION
> **Blocked on two core PRs — do not merge before they land.** `JWT_DECODE_HANDLER` points at
> `core.auth.decode`, which does not exist on `openimis-be-core_py@develop`
> (`git ls-tree origin/develop` shows `core/jwt.py` but no `core/auth/`). Since `openimis.json`
> pins core to `@develop`, merging this first would 500 the first authenticated request. Needs
> openimis/openimis-be-core_py#468 (OP-3126) and #469 (OP-3127) on `develop`. Draft until then.
> The branch itself is cut from `develop`, so the diff below is only this ticket's 7 commits.

## Why

The assembly's JWT settings describe a signing mechanism that does not work, and the README tells
operators to enable it.

`settings/security.py` loaded an RSA keypair from `BASE_DIR/keys/` and, if both PEMs were present,
set `JWT_ALGORITHM: RS256` with `JWT_PRIVATE_KEY`/`JWT_PUBLIC_KEY`. But `JWT_ENCODE_HANDLER` resolves
its key through `core.jwt.get_jwt_key`, which returns the user's `private_key` — the **password
salt** (`core/models/user.py:426-431`) — and only falls back to `JWT_PRIVATE_KEY` when there is
none. So the one configuration that loads an RSA key cannot use it for any user who has a password.

Measured on **`develop`** (`ghcr.io/openimis/openimis-be:develop`, no `core/auth`) through the full
`openimis-dist_dkr` stack — a real `tokenAuth` login as `Admin` over nginx, with the presence of the
two PEM files as the only variable:

| `BASE_DIR/keys/` | `tokenAuth` |
|---|---|
| absent | login OK — `{"alg":"HS256"}` |
| both PEMs present | **login fails** — `Unable to load PEM file … MalformedFraming` |

The backend logs `GraphQLLocatedError: Unable to load PEM file` server-side.

`MalformedFraming` reads like a broken key file. It is not: PyJWT's RS256 path passes the *key
argument* to `load_pem_private_key`, so `cryptography` is reporting the **password salt** as an
unparseable PEM. Checked separately — the mounted PEMs pass `openssl rsa -check` and load cleanly,
and `jwt.encode(payload, <64-hex salt>, algorithm="RS256")` produces the identical message with no
key files present at all. Had the PEMs been malformed, `security.py` would have raised at settings
import and the container would not have booted.

On the `25.10` release image the same failure reproduces for a salted user, while a user with a NULL
`private_key` gets a working RS256 token — exactly the split the precedence bug predicts. Every one
of the 31 interactive users in the demo database is salted, so such a deployment is a total login
outage rather than a subtle misconfiguration. And `README.md` was instructing operators into exactly
that state: *"Place jwt_private_key.pem and jwt_public_key.pem … e.g., keys/"*.

**This is not dead code that the core work already neutralises.** With current core and a deployment
key provisioned, the PEMs still break *decoding*: `LegacyUserKeyProvider` reads
`jwt_settings.JWT_ALGORITHM` (`core/auth/providers/legacy.py:32`) and `JWT_PUBLIC_KEY` (`:63`). A
legacy token that decodes fine without `keys/` fails with `InvalidAlgorithmError: The specified alg
value is not allowed` with it — breaking the migration window #468 and #469 exist to protect.

## What changes

- **Removes** the `keys/` RSA branch and the two imports it orphaned (`serialization`, `BASE_DIR`,
  plus stale `timedelta`/`serialization` in `settings/__init__.py`).
- **`JWT_SIGNING_KEY`** — top-level, from the environment. Provisioning the key is the switch; there
  is no mode setting. Takes a path to a mounted PEM or an inline PEM.
- **`JWT_ISSUER` / `JWT_AUDIENCE`** — inside `GRAPHQL_JWT`, because core reads them through
  `jwt_settings`. `graphql_jwt`'s default payload handler writes the claims from these, so no
  encoder change is needed.
- **`JWT_DECODE_HANDLER` → `core.auth.decode`** — a rename onto what the old shim already called.
- Documents all three in `.env.example`, and replaces the README's RSA-keys section.

## What does not change

- **Every setting defaults to unset, so upgrading changes nothing.** Verified byte-identical: token
  header `{"alg":"HS256"}`, no `kid`/`iss`/`aud`, `current_user` 200.
- **`JWT_ENCODE_HANDLER` stays on `core.jwt.jwt_encode_user_key`**, deliberately.
  `core.auth.encode.encode` raises when no key is provisioned, and provisioning (OP-3132) lands after
  this, so repointing here would break login everywhere. The shim already dispatches on key presence.
  The repoint belongs with OP-3129, where `JWT_SIGNING_KEY` becomes required.
- No migration, no dependency change, no `setup.py` touch.
- `api_fhir_r4` is unaffected — it imports `jwt_encode_user_key` directly, bypassing the setting.

## Tests

`core` suite **318 passing, OK** — unchanged from the branch-point baseline; this is a settings
change and adds no tests. flake8: `security.py` **1 finding** (pre-existing `E501`),
`settings/__init__.py` **2** (pre-existing `E265`, `W391`) — no new findings in any touched file.
`manage.py check`: no issues, 0 silenced.

Verified end to end on `openimis-dist_dkr` (nginx → backend → Postgres, three Celery workers,
frontend), on an image carrying this branch plus current core:

| Check, through `/api` | nothing set | key + issuer + audience |
|---|---|---|
| GraphQL introspection | `queryType: Query` | same |
| token header | `{"alg":"HS256"}`, no `kid` | `{"alg":"RS256","kid":"Pv1bpYvt…"}` |
| `iss` / `aud` | absent | present |
| `GET /api/core/users/current_user/` | 200 | 200 |
| pre-switch token afterwards | n/a | 401 |
| workers | 3/3 healthy | 3/3 healthy |

A worker reports the same `kid` as the backend and decodes a backend-issued token, which is what
OP-3132's shared-key requirement needs.

## Release note

**Setting `JWT_ISSUER` or `JWT_AUDIENCE` logs every user out once.** Tokens issued before it was set
carry no `iss`/`aud`, and PyJWT's `verify_iss` is on by default, so they stop verifying immediately
(measured: 401). Tokens expire after a day; set it during a maintenance window. Clearing the variable
rolls it back.

For any deployment that had `keys/*.pem` mounted, this restores login for password users and
invalidates outstanding RS256 tokens held by users with a NULL `private_key`.

## Follow-ups

- **OP-3132** — provision the keypair in `openimis-dist_dkr`: the three variables must be added to
  the `x-api` anchor's enumerated `environment:` list (`compose.base.yml:4-21`); putting them only in
  `.env` does not reach the containers, as that list is not a blanket passthrough.
- **OP-3129** — removes the per-user path, makes `JWT_SIGNING_KEY` required via a startup check, and
  repoints `JWT_ENCODE_HANDLER`. Note the handler string is `core.auth.encode.encode`:
  `import_string` splits on the last dot, so `core.auth.encode` resolves to the module.

Ticket: OP-3131
